### PR TITLE
V2 Phase 1 - Issue 2: Session repository boundary

### DIFF
--- a/.ai/v2-plan/GitHubWorkflow.md
+++ b/.ai/v2-plan/GitHubWorkflow.md
@@ -13,7 +13,7 @@ Before using the workflow below for any active phase, follow the required startu
 1. **Source of truth (`.ai/v2-plan/` files):** All architectural decisions, phase scope, and subphase checklists live here. If anything changes, update these files first.
 
 2. **Milestones (one per phase):** Each phase file maps directly to a GitHub Milestone.
-   - Naming: `Phase N: <Phase Name>` — e.g. `Phase 1: Session Boundary Cleanup`
+   - Naming: `V2 Phase N: <Phase Name>` — e.g. `V2 Phase 1: Session Boundary Cleanup`
    - Full phase list: see [ImplementationPlan.md](ImplementationPlan.md)
 
 3. **Issues (fit the granularity to the nature of the phase):** Each milestone contains multiple issues. The right number and granularity varies by phase — some phases call for one issue per feature domain, others for one per screen, others for one per component. A single pattern forced across all phases creates either too many micro-issues or too few meaningful ones.
@@ -59,6 +59,7 @@ A phase is complete when **all** of the following are true — none can happen w
 
 - [ ] All subphase checkboxes in the phase file are ticked
 - [ ] All acceptance criteria are met
+- [ ] `Architecture.md` or another current-state explainer is updated when the phase changed the project's actual architecture or implementation reality
 - [ ] All PRs for this phase are merged into `architecture-improvement`
 - [ ] All issues in the milestone are closed
 - [ ] The milestone is closed
@@ -104,7 +105,7 @@ For every phase, use this order before writing code:
 The `gh-milestone` extension is already installed:
 
 ```bash
-gh milestone create --title "Phase 1: Session Boundary Cleanup"
+gh milestone create --title "V2 Phase 1: Session Boundary Cleanup"
 ```
 
 Create milestones one at a time as you are ready to start each phase — no need to create all upfront.
@@ -113,7 +114,7 @@ Create milestones one at a time as you are ready to start each phase — no need
 
 ```bash
 # Create the issue
-gh issue create --title "[Phase 1] Create SessionRepository and root coordinator" --milestone "Phase 1: Session Boundary Cleanup"
+gh issue create --title "[Phase 1] Create SessionRepository and root coordinator" --milestone "V2 Phase 1: Session Boundary Cleanup"
 
 # Add it to the LifeTogether Board (project number 2)
 gh project item-add 2 --owner DetGrey --url "https://github.com/DetGrey/LifeTogether/issues/<issue-number>"
@@ -126,7 +127,7 @@ The CLI will prompt for a body when creating the issue — paste the relevant su
 Use this when the milestone must be visible on the project board before the real issues exist:
 
 ```bash
-gh project item-create 2 --owner DetGrey --title "Phase 1: Session Boundary Cleanup" --body "Milestone placeholder for Phase 1. Replace draft visibility with real milestone issues as they are created."
+gh project item-create 2 --owner DetGrey --title "V2 Phase 1: Session Boundary Cleanup" --body "Milestone placeholder for Phase 1. Replace draft visibility with real milestone issues as they are created."
 ```
 
 ### 3. Branch and Commit

--- a/.ai/v2-plan/GitHubWorkflow.md
+++ b/.ai/v2-plan/GitHubWorkflow.md
@@ -70,14 +70,16 @@ A phase is complete when **all** of the following are true — none can happen w
 ## Daily Execution Workflow
 
 1. **Pick up an issue:** Go to the LifeTogether Board, pick an issue from the current milestone, and move it to **In Progress**.
-2. **Branch:** Create a branch from `architecture-improvement` using the format `<issue-id>-<short-description>` — e.g. `git checkout -b 15-session-setup`
+2. **Branch + issue connection:** Connect the issue to its branch before coding.
+   - Preferred: create the branch from the issue so GitHub tracks it in Development (`gh issue develop <issue-number> --base architecture-improvement --name <branch-name>`)
+   - If the branch already exists or linking cannot be created, add explicit branch and PR references in the issue body and keep them updated.
 3. **Micro-commits:** Write code and commit using the convention `[Phase N] Short description`.
 4. **Pull Request:** Open a PR targeting `architecture-improvement`.
    - Do not write `Closes #N` unless the PR completes the *entire* issue.
    - Instead write: `Relates to #N` or `Completes SessionRepository setup for #N`.
    - **Never merge a PR without explicit user approval first.**
-5. **Tick checkboxes:** As PRs are merged, manually tick the checkboxes in the issue body.
-6. **Close:** Once all checkboxes are ticked, close the issue.
+5. **Tick checkboxes:** When an issue is completed, edit the issue body so completed checklist items are checked (`- [x]`) before closing.
+6. **Close:** Once all relevant checkboxes are ticked, close the issue.
    - **Never close an issue or milestone without explicit user approval first.**
    - A phase is only complete when all issues are closed, all PRs are merged, and the milestone is closed — see Definition of Complete above.
 
@@ -136,8 +138,12 @@ gh project item-create 2 --owner DetGrey --title "V2 Phase 1: Session Boundary C
 # See what is open
 gh issue list
 
-# Create your branch from architecture-improvement — use the issue ID (e.g. issue #15)
-git checkout -b 15-session-setup
+# Preferred: create and link the issue branch from GitHub issue development
+gh issue develop 15 --base architecture-improvement --name V2/15-session-setup
+git checkout V2/15-session-setup
+
+# Fallback: if needed, create branch manually and then record the branch in issue body
+git checkout -b V2/15-session-setup
 
 # Commit using the convention
 git commit -m "[Phase 1] Add SessionRepository interface and Hilt singleton"
@@ -146,7 +152,7 @@ git commit -m "[Phase 1] Add SessionRepository interface and Hilt singleton"
 ### 4. Update Issue Checkboxes
 
 ```bash
-# Opens the issue in your terminal editor
+# Opens the issue in your terminal editor (mark completed checklist items as - [x])
 gh issue edit 15
 ```
 

--- a/.ai/v2-plan/PhaseExecutionFlow.md
+++ b/.ai/v2-plan/PhaseExecutionFlow.md
@@ -83,12 +83,14 @@ Only after the phase file, milestone, and issues are ready:
 
 - pick the first issue
 - move that issue to `In Progress` on the **LifeTogether Board** immediately before doing implementation work
+- connect the issue to its implementation branch (prefer GitHub-linked issue branch flow before coding; otherwise add explicit branch + PR references in the issue body)
 - create a branch from `architecture-improvement` using the branch format from [GitHubWorkflow.md](GitHubWorkflow.md)
 - begin coding from the issue content that was already agreed and written down
 
 Required outcome:
 
 - implementation never starts on an issue that is still in `Todo`/not started on the board
+- the active issue has an explicit branch connection for traceability
 - coding starts from an issue branch, not directly from `architecture-improvement`
 - the issue already contains the implementation context agreed during the grill-me phase
 
@@ -103,6 +105,7 @@ For each phase, the flow is:
 3. grill-me the final issue breakdown
 4. create the issues from the phase file and connect them to the milestone and project
 5. move the active issue to `In Progress`, create the issue branch, and start coding
+6. when the issue is complete, update the issue body so all completed checkboxes are checked before closing
 
 ---
 

--- a/.ai/v2-plan/PhaseExecutionFlow.md
+++ b/.ai/v2-plan/PhaseExecutionFlow.md
@@ -6,6 +6,8 @@ The phase markdown file remains the source of truth for that phase's scope, subp
 
 No implementation work starts until this flow is completed for the active phase.
 
+This flow also defines the minimum level of detail required in the phase file before implementation starts. The grill-me session must not stop at high-level agreement. It must drive the phase file to concrete implementation detail for each subphase, capture important design decisions made during the conversation, and keep the phase markdown aligned with those decisions as they are made.
+
 ---
 
 ## Required Order For Each Phase
@@ -17,10 +19,20 @@ Use the `grill-me` skill with the active phase file and finish the pre-implement
 This step must:
 
 - finalise the subphases
-- finalise the acceptance criteria
-- finalise the test cases
+- add implementation detail for how each subphase is expected to be implemented
+- finalise the acceptance criteria as Markdown checkboxes (`- [ ]`)
+- finalise the test cases as Markdown checkboxes (`- [ ]`)
 - answer all open questions in the phase file
 - update the phase file with the agreed decisions before proceeding
+
+Required detail level:
+
+- each subphase should say not only what will be done, but how it should be implemented where that detail is already known
+- important boundary decisions, ownership decisions, lifecycle decisions, migration strategy decisions, and deletion decisions must be written into the phase file during grill-me rather than left implicit in chat history
+- if the conversation creates or changes a standing rule for future phase prep, update the relevant source-of-truth markdown file in `.ai/v2-plan/` during the same session
+- if a phase changes the current architecture or current implementation reality of the project, the implementation work for that phase must also update `Architecture.md` or another current-state project explainer so it reflects the new reality
+- historical implementation/phase/plan files must keep their historical references; do not remove old decisions or references from phase files just to make the current-state docs cleaner
+- do not add catch-all sections such as `Resolved during grill-me` that dump unrelated decisions together; decisions must be incorporated into the relevant existing sections, or into a new well-named section when they do not fit anywhere else
 
 The phase file should be moved from `Not started` to `Grill-me in progress` during this process when appropriate.
 
@@ -49,6 +61,7 @@ Required outcome:
 - the issue list for the phase is confirmed
 - the phase file's `## GitHub Issues` section matches the agreed breakdown
 - issue granularity fits the actual nature of the phase rather than forcing a fixed pattern
+- the issue bodies can be created directly from the phase file without losing implementation detail agreed during grill-me
 
 ### 4. Create the issues from the phase file and connect them properly
 
@@ -100,3 +113,4 @@ This flow exists to prevent:
 - issue lists being decided too early or too loosely
 - GitHub issues losing the detailed information already agreed in the phase file
 - implementation starting without project tracking in place
+- grill-me sessions ending with only high-level intent instead of implementation-ready phase detail

--- a/.ai/v2-plan/PhaseExecutionFlow.md
+++ b/.ai/v2-plan/PhaseExecutionFlow.md
@@ -82,11 +82,13 @@ Required issue rule:
 Only after the phase file, milestone, and issues are ready:
 
 - pick the first issue
+- move that issue to `In Progress` on the **LifeTogether Board** immediately before doing implementation work
 - create a branch from `architecture-improvement` using the branch format from [GitHubWorkflow.md](GitHubWorkflow.md)
 - begin coding from the issue content that was already agreed and written down
 
 Required outcome:
 
+- implementation never starts on an issue that is still in `Todo`/not started on the board
 - coding starts from an issue branch, not directly from `architecture-improvement`
 - the issue already contains the implementation context agreed during the grill-me phase
 
@@ -100,7 +102,7 @@ For each phase, the flow is:
 2. create the milestone and represent the phase on the project board
 3. grill-me the final issue breakdown
 4. create the issues from the phase file and connect them to the milestone and project
-5. create the first issue branch and start coding
+5. move the active issue to `In Progress`, create the issue branch, and start coding
 
 ---
 

--- a/.ai/v2-plan/phases/Phase01-SessionBoundary.md
+++ b/.ai/v2-plan/phases/Phase01-SessionBoundary.md
@@ -1,6 +1,6 @@
 # Phase 1 — Session Boundary Cleanup
 
-**Status:** Not started _(Not started → Grill-me in progress → Implementing → Complete)_
+**Status:** Grill-me in progress _(Not started → Grill-me in progress → Implementing → Complete)_
 
 ## Goal
 
@@ -26,14 +26,79 @@ Extract durable app session state into a dedicated `SessionRepository`, move obs
 
 ## Subphases
 
-_To be finalised during the pre-implementation grill-me session._
+- [ ] 1.1 Define `SessionState` as an explicit session model and implement `SessionRepository` as a Hilt singleton
+  - Recommended file placement: `SessionRepository` in `domain/repository/`, `SessionState` in `domain/model/`, `SessionRepositoryImpl` in `data/repository/`
+  - Prefer `SessionState` as a sealed interface with `data object` / `data class` variants if supported cleanly by the project Kotlin version; fallback to sealed class or plain `object` variants only if necessary
+  - `SessionState` shape: `Loading`, `Unauthenticated`, `Authenticated(user: UserInformation)`
+  - `SessionRepository` owns auth-state observation, current user loading, durable session state exposure, and sign-out entry point
+  - `SessionRepository.signOut()` absorbs the full existing logout behavior: remote logout/device-token removal, local session clearing, and transition to `SessionState.Unauthenticated`
+  - `SessionRepositoryImpl` should be an eager singleton that starts session observation in `init`
+  - Use an application-level coroutine scope injected through Hilt for the long-lived auth/session observation loop
+  - Keep the public API minimal in phase 1: `val sessionState: StateFlow<SessionState>` and `suspend fun signOut(): ResultListener`
+  - Do not expose parallel convenience flows like `uidFlow`, `familyIdFlow`, or `userInformationFlow` in phase 1
+  - Internal transition rule: `Loading` while auth/user state is being resolved; `Authenticated(user)` only after full `UserInformation` load succeeds; if Firebase auth is signed in but user-info lookup fails, log it and transition to `Unauthenticated`
+  - Provide `SessionRepository` and the application-level coroutine scope from a dedicated Hilt module installed in `SingletonComponent`
+  - If an application-level `CoroutineScope` is added, qualify it explicitly to avoid ambiguous scope injection later
+- [ ] 1.2 Define and implement the activity-scoped root coordinator ViewModel
+  - Recommended file placement: root coordinator ViewModel in `ui/viewmodel/`
+  - Root coordinator reacts to `SessionState`
+  - Owns observer coordination, guide progress sync scheduling, and FCM token sync triggering
+  - FCM sync triggers only when authenticated `uid` and `familyId` are both present, and only when identity context changes
+  - Implement session reactions as explicit private handlers per concern rather than one monolithic collector
+  - Track last-applied identity context separately for observers, guide sync, and FCM sync so reactions stay idempotent
+  - On `Unauthenticated`, cancel guide sync, clear remembered contexts, and cancel all non-auth observers
+  - On `Authenticated(user)`, sync observer context if changed, start/restart guide sync when `familyId` is valid and context changed, and trigger FCM sync only when both `uid` and `familyId` are valid and changed
+- [ ] 1.3 Update `MainActivity` to use the root coordinator + `SessionRepository`
+  - Remove `AppSessionViewModel` usage
+  - Move app-start session reactions out of composable side effects tied directly to `AppSessionViewModel`
+  - Keep `MainActivity` focused on app-root setup and root-scoped dependencies rather than session-driven navigation branching
+- [ ] 1.4 Update `NavHost` and route composables to remove all `AppSessionViewModel` parameter threading
+  - `NavHost` must not accept `AppSessionViewModel`
+  - Route composables must not know about session orchestration
+  - `LoadingScreen` may keep ownership of login-vs-home routing in phase 1, but it should depend on plain session state input rather than an app-scoped session ViewModel
+  - Prefer direct plain session-state collection for startup loading flow rather than introducing a dedicated `LoadingViewModel` unless implementation friction clearly requires one
+  - Graph-aware observer helpers such as the gallery graph may keep route-level navigation-condition logic, but they must only decide when to bind observer keys and must not pass session context
+  - Preserve existing route files in phase 1 even when they become thinner; route/screen structural cleanup belongs to a later phase unless a route becomes impossible to keep
+- [ ] 1.5 Update `ObserverLifecycle` to align with root coordinator ownership
+  - `FeatureObserverLifecycleBinding` takes observer keys only
+  - No `uid` / `familyId` / `AppSessionViewModel` parameters
+  - `FeatureObserverLifecycleBinding` and `ObserverUpdatingText` should resolve the activity-scoped root coordinator internally instead of receiving it through route/screen parameter threading
+  - Route composables may still decide which observer keys to bind and under what route-specific conditions, but they must not pass session context into observer plumbing
+  - UI-facing observer ownership should be fully cleaned up in phase 1, but internal `ObserverCoordinator` API changes should stay modest unless they are required to unblock the migration
+  - It is acceptable for the root coordinator to remain the layer that translates `SessionState` into calls on `ObserverCoordinator`
+- [ ] 1.6 Migrate remaining feature code off `AppSessionViewModel`
+  - Feature ViewModels inject `SessionRepository` directly when they need reactive session access
+  - Screens stop reading `uid` / `familyId` from an app-scoped ViewModel
+  - Even screens with heavy current-user rendering requirements should get session-backed data from their own feature ViewModel rather than reading session directly in the composable
+  - Route-level temporary session extraction should not be kept as a compatibility shortcut unless there is a blocker that clearly belongs to a later phase
+  - Feature ViewModels should map only the session-backed fields each screen actually needs into their own UI-facing state rather than exposing raw `SessionState` directly to the composable
+  - Profile/Family/Settings-style screens should delegate sign-out and other session-backed actions through their own ViewModel APIs
+  - A very small shared helper/extension for common `SessionState` extraction is allowed, such as authenticated user or familyId lookup, but phase 1 must not create a second broad session abstraction
+  - In Android UI files touched during this migration, prefer `collectAsStateWithLifecycle()` for new or replaced session-related collection points, but do not widen phase 1 into a mass collection-API sweep
+  - Expected migration targets in this phase include startup/auth gating (`LoadingScreen`), user-data-heavy screens (`ProfileScreen`, `FamilyScreen`, `SettingsScreen`, `HomeScreen`), setup-driven feature screens (`GroceryListScreen`, `RecipesScreen`, `RecipeDetailsScreen`, `GuidesScreen`, `GuideCreateScreen`, `GuideDetailsScreen`, `GuideStepPlayerScreen`, `ListsScreen`, `ListDetailsScreen`, `ListEntryDetailsScreen`, `GalleryScreen`, `AlbumDetailsScreen`, `MediaDetailsScreen`, `TipTrackerScreen`, `TipStatisticsScreen`), and observer-only routes (grocery, recipes, guides, lists, tip tracker, gallery graph, admin grocery routes)
+  - Feature ViewModels that depend on session context must react coherently to context changes: start/restart work when required context becomes valid or changes, and clear/reset state when required context becomes invalid
+  - Existing `setUp(...)` / `setUpX(...)` APIs may remain temporarily in phase 1 if removing them would widen the phase, but they must stop requiring session-derived parameters from routes/screens and should only keep true screen-specific inputs like IDs or nav arguments
+  - ViewModels with jobs or collectors keyed by session context must cancel old jobs before starting new ones, clear stale state when context becomes invalid, and replace one-time setup booleans with real context-keyed restart logic where needed
+  - ViewModels that always need session context may observe `SessionRepository` in `init`; ViewModels that also require true screen-specific input should combine that input with session context internally rather than pushing session composition back to routes
+  - ID-based screens should pass only true navigation input from routes; the ViewModel must own composition of screen-specific IDs plus session context and must reset or restart correctly when either side of that keyed context changes
+  - When required session context becomes invalid, migrated feature ViewModels should reset or clear state without inventing new feature-specific error UI; app/session routing should handle the broader transition
+- [ ] 1.7 Delete `AppSessionViewModel` and remove `itemCount` completely
+  - No compatibility wrapper kept after migration
+  - Remove all `itemCount` state and update calls, even if partially wired to local or remote persistence
 
-- [ ] 1.1 Define and implement `SessionRepository` interface and Hilt-provided singleton
-- [ ] 1.2 Define and implement root coordinator ViewModel (activity-scoped)
-- [ ] 1.3 Update `MainActivity` to use root coordinator instead of `AppSessionViewModel`
-- [ ] 1.4 Update `NavHost` to remove `AppSessionViewModel` parameter threading
-- [ ] 1.5 Update `ObserverLifecycle` to align with new coordinator ownership
-- [ ] 1.6 Migrate any remaining direct `AppSessionViewModel` references
+### Recommended Implementation Order
+
+- [ ] Step A: Add singleton DI + application coroutine scope + `SessionState` + `SessionRepository`
+- [ ] Verify compilation after Step A / the first issue slice
+- [ ] Step B: Add the activity-scoped root coordinator and wire its session reaction loop
+- [ ] Verify compilation after Step B / the second issue slice
+- [ ] Step C: Switch `MainActivity` to the root coordinator and remove app-start `AppSessionViewModel` side effects
+- [ ] Step D: Migrate observer lifecycle infrastructure to root coordinator ownership
+- [ ] Step E: Remove `NavHost` parameter threading and clean route observer bindings
+- [ ] Step F: Migrate feature/session consumers screen-by-screen through their own ViewModels
+- [ ] Step G: Delete `AppSessionViewModel`, delete `itemCount`, and sweep remaining references
+- [ ] Verify final compilation after Step G / the final issue slice
+- [ ] Step H: Update `Architecture.md` or another current-state explainer to reflect the finished phase
 
 ## Before Starting This Phase
 
@@ -44,18 +109,58 @@ _To be finalised during the pre-implementation grill-me session._
 > All **Open Questions** at the bottom of this file must be answered and the section removed before implementation begins.
 
 ### Acceptance criteria
-_To be defined during the pre-implementation grill-me session._
+
+- [ ] `SessionRepository` exists as the single durable session boundary and exposes `StateFlow<SessionState>`
+- [ ] `SessionState` is explicit and no screen depends on the old `loading + nullable userInformation` contract
+- [ ] The root coordinator ViewModel is activity-scoped and owns observer coordination, guide sync orchestration, and FCM token sync triggering
+- [ ] `MainActivity` no longer creates or depends on `AppSessionViewModel`
+- [ ] `NavHost` and all route/screen composables no longer accept or thread `AppSessionViewModel`
+- [ ] `FeatureObserverLifecycleBinding` no longer accepts `uid`, `familyId`, or `AppSessionViewModel`
+- [ ] Feature ViewModels that need session data depend on `SessionRepository` directly via Hilt
+- [ ] Sign-out flows go through `SessionRepository.signOut()` and result in clean transition to `SessionState.Unauthenticated`
+- [ ] Remote logout/device-token removal behavior remains intact after the sign-out refactor
+- [ ] FCM token sync triggers only when authenticated `uid` and `familyId` are both available, and does not retrigger unnecessarily when identity context is unchanged
+- [ ] `AppSessionViewModel` is deleted by the end of the phase
+- [ ] `itemCount` is fully removed from the codebase and not relocated into `SessionRepository` or the root coordinator
+- [ ] Preview-blocking `"Preview requires AppSessionViewModel"` placeholders touched by this migration are removed
+- [ ] `Architecture.md` or another current-state explainer is updated to reflect the new session boundary and root coordinator ownership without removing historical references from the v2 planning files
 
 ### Test cases
-_To be defined during the pre-implementation grill-me session._
+
+- [ ] App startup while auth state is unresolved exposes `SessionState.Loading`, then resolves to either `Authenticated` or `Unauthenticated`
+- [ ] Authenticated startup with valid `uid` and `familyId` triggers root coordinator setup, including observer context sync and one FCM sync attempt for that identity context
+- [ ] Authenticated startup with missing `familyId` does not start family-scoped observers or guide sync and does not trigger FCM token sync
+- [ ] Sign-out clears session state to `Unauthenticated`, preserves remote logout/device-token removal behavior, and tears down non-auth observers plus guide sync orchestration
+- [ ] Re-entering the same authenticated identity context does not duplicate FCM token sync work
+- [ ] `FeatureObserverLifecycleBinding` acquires and releases observer keys without requiring route-level session arguments
+- [ ] Key feature ViewModels compile and run with `SessionRepository` injection instead of `AppSessionViewModel` threading
+- [ ] Loading/navigation gating still routes authenticated users to home and unauthenticated users to login
+- [ ] Codebase compiles with no remaining `AppSessionViewModel` references
+- [ ] Codebase compiles with no remaining `itemCount` references
+- [ ] Compilation is verified after each major issue slice, not only at the end of the phase
 
 ## GitHub Issues
 
-Create milestone `Phase 1: Session Boundary Cleanup` and the following issues assigned to it:
+Create milestone `V2 Phase 1: Session Boundary Cleanup` and the following issues assigned to it:
 
-- `[Phase 1] Create SessionRepository and root coordinator`
-- `[Phase 1] Migrate AppSessionViewModel references`
+- `[Phase 1] Create SessionRepository and SessionState`
+- `[Phase 1] Create root coordinator and observer lifecycle migration`
+- `[Phase 1] Remove AppSessionViewModel and itemCount references`
 
-## Open Questions
+Issue ownership expectations:
 
-- Which current or future feature ViewModels truly need to observe session changes reactively vs. receive session input once at route level?
+- `[Phase 1] Create SessionRepository and SessionState`
+  - Owns singleton DI additions, application coroutine scope, `SessionState`, `SessionRepository`, `SessionRepositoryImpl`, sign-out boundary migration, and any small `SessionState` helper needed by feature ViewModels
+- `[Phase 1] Create root coordinator and observer lifecycle migration`
+  - Owns root coordinator ViewModel, `MainActivity` root wiring, observer lifecycle helpers, graph observer migration, and route observer cleanup that removes session/context plumbing from UI-facing observer code
+- `[Phase 1] Remove AppSessionViewModel and itemCount references`
+  - Owns feature ViewModel/session-consumer migration, removal of direct session reads from screens/routes, deletion of `AppSessionViewModel`, deletion of `itemCount`, final reference sweep, and `Architecture.md` or equivalent current-state documentation update
+
+Issue body expectations:
+
+- Each issue body should include:
+  - issue-specific scope/ownership
+  - the relevant subphase checklist items copied from this phase file
+  - the relevant acceptance criteria copied from this phase file
+  - the relevant test/verification checklist items copied from this phase file
+  - a short `Out of scope` section that names which work belongs to the other Phase 1 issues or to later phases

--- a/app/src/main/java/com/example/lifetogether/data/remote/FirebaseAuthDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/remote/FirebaseAuthDataSource.kt
@@ -74,6 +74,8 @@ class FirebaseAuthDataSource@Inject constructor(
         }
     }
 
+    fun currentUserUid(): String? = FirebaseAuth.getInstance().currentUser?.uid
+
     suspend fun logout(
         uid: String,
         familyId: String?,

--- a/app/src/main/java/com/example/lifetogether/data/remote/FirestoreDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/remote/FirestoreDataSource.kt
@@ -90,11 +90,30 @@ class FirestoreDataSource @Inject constructor() {
                 Log.d(TAG, "Snapshot of userInformation: loaded")
                 if (userInformation != null) {
                     trySend(AuthResultListener.Success(userInformation)).isSuccess
+                } else {
+                    trySend(AuthResultListener.Failure("User not found")).isSuccess
                 }
+            } else {
+                trySend(AuthResultListener.Failure("User not found")).isSuccess
             }
         }
         // Await close tells the flow builder to suspend until the flow collector is cancelled or disposed.
         awaitClose { listenerRegistration.remove() }
+    }
+
+    suspend fun fetchUserInformation(uid: String): AuthResultListener {
+        return try {
+            val snapshot = db.collection(Constants.USER_TABLE).document(uid).get().await()
+            val userInformation = snapshot.toObject(UserInformation::class.java)
+            if (userInformation != null) {
+                AuthResultListener.Success(userInformation)
+            } else {
+                AuthResultListener.Failure("User not found")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "fetchUserInformation failed for uid=$uid", e)
+            AuthResultListener.Failure("Error: ${e.message}")
+        }
     }
 
     suspend fun uploadUserInformation(userInformation: UserInformation): ResultListener {

--- a/app/src/main/java/com/example/lifetogether/data/repository/LocalUserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/lifetogether/data/repository/LocalUserRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.example.lifetogether.domain.listener.ResultListener
 import com.example.lifetogether.domain.model.UserInformation
 import com.example.lifetogether.domain.model.family.FamilyInformation
 import com.example.lifetogether.domain.model.family.FamilyMember
+import com.example.lifetogether.domain.repository.SessionLocalUserRepository
 import com.example.lifetogether.domain.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -15,7 +16,7 @@ import javax.inject.Inject
 
 class LocalUserRepositoryImpl @Inject constructor(
     private val localDataSource: LocalDataSource,
-) : UserRepository {
+) : UserRepository, SessionLocalUserRepository {
     fun getUserInformation(uid: String): Flow<AuthResultListener> {
         return localDataSource.getUserInformation(uid).map { user ->
             try {
@@ -88,7 +89,7 @@ class LocalUserRepositoryImpl @Inject constructor(
         }
     }
 
-    fun removeSavedUserInformation(): ResultListener {
+    override fun removeSavedUserInformation(): ResultListener {
         return localDataSource.clearUserInformationTables()
     }
 }

--- a/app/src/main/java/com/example/lifetogether/data/repository/RemoteUserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/lifetogether/data/repository/RemoteUserRepositoryImpl.kt
@@ -7,13 +7,15 @@ import com.example.lifetogether.domain.listener.ResultListener
 import com.example.lifetogether.domain.listener.StringResultListener
 import com.example.lifetogether.domain.model.User
 import com.example.lifetogether.domain.model.UserInformation
+import com.example.lifetogether.domain.repository.SessionRemoteUserRepository
 import com.example.lifetogether.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class RemoteUserRepositoryImpl @Inject constructor(
     private val firebaseAuthDataSource: FirebaseAuthDataSource,
     private val firestoreDataSource: FirestoreDataSource,
-) : UserRepository {
+) : UserRepository, SessionRemoteUserRepository {
     suspend fun login(
         user: User,
     ): AuthResultListener {
@@ -48,11 +50,19 @@ class RemoteUserRepositoryImpl @Inject constructor(
         }
     }
 
-    suspend fun logout(
+    override suspend fun logout(
         uid: String,
         familyId: String?,
     ): ResultListener {
         return firebaseAuthDataSource.logout(uid, familyId)
+    }
+
+    override suspend fun fetchUserInformation(uid: String): AuthResultListener {
+        return firestoreDataSource.fetchUserInformation(uid)
+    }
+
+    override fun observeUserInformation(uid: String): Flow<AuthResultListener> {
+        return firestoreDataSource.userInformationSnapshotListener(uid)
     }
 
     suspend fun changeName(

--- a/app/src/main/java/com/example/lifetogether/data/repository/SessionRepositoryImpl.kt
+++ b/app/src/main/java/com/example/lifetogether/data/repository/SessionRepositoryImpl.kt
@@ -1,0 +1,106 @@
+package com.example.lifetogether.data.repository
+
+import android.util.Log
+import com.example.lifetogether.data.remote.FirebaseAuthDataSource
+import com.example.lifetogether.di.AppScope
+import com.example.lifetogether.domain.listener.AuthResultListener
+import com.example.lifetogether.domain.listener.ResultListener
+import com.example.lifetogether.domain.model.UserInformation
+import com.example.lifetogether.domain.model.session.SessionState
+import com.example.lifetogether.domain.model.session.authenticatedUserOrNull
+import com.example.lifetogether.domain.repository.SessionLocalUserRepository
+import com.example.lifetogether.domain.repository.SessionRemoteUserRepository
+import com.example.lifetogether.domain.repository.SessionRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SessionRepositoryImpl @Inject constructor(
+    @param:AppScope private val appScope: CoroutineScope,
+    private val firebaseAuthDataSource: FirebaseAuthDataSource,
+    private val sessionRemoteUserRepository: SessionRemoteUserRepository,
+    private val sessionLocalUserRepository: SessionLocalUserRepository,
+) : SessionRepository {
+    companion object {
+        private const val TAG = "SessionRepository"
+    }
+
+    private val _sessionState = MutableStateFlow<SessionState>(SessionState.Loading)
+    override val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
+
+    init {
+        appScope.launch {
+            firebaseAuthDataSource.authStateListener().collectLatest { authState ->
+                when (authState) {
+                    is AuthResultListener.Success -> {
+                        val uid = authState.userInformation.uid
+                        if (uid.isNullOrBlank()) {
+                            _sessionState.value = SessionState.Unauthenticated
+                            return@collectLatest
+                        }
+
+                        _sessionState.value = SessionState.Loading
+                        sessionRemoteUserRepository.observeUserInformation(uid).collect { result ->
+                            when (result) {
+                                is AuthResultListener.Success -> {
+                                    _sessionState.value = SessionState.Authenticated(result.userInformation)
+                                }
+
+                                is AuthResultListener.Failure -> {
+                                    Log.w(TAG, "User information lookup failed for uid=$uid: ${result.message}")
+                                    _sessionState.value = SessionState.Unauthenticated
+                                }
+                            }
+                        }
+                    }
+
+                    is AuthResultListener.Failure -> {
+                        _sessionState.value = SessionState.Unauthenticated
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun signOut(): ResultListener {
+        val currentUser = resolveUserForSignOut()
+            ?: return ResultListener.Failure("No authenticated user available for sign out")
+
+        val uid = currentUser.uid
+            ?: return ResultListener.Failure("No authenticated user available for sign out")
+
+        return when (val remoteResult = sessionRemoteUserRepository.logout(uid, currentUser.familyId)) {
+            is ResultListener.Failure -> remoteResult
+            is ResultListener.Success -> {
+                _sessionState.value = SessionState.Unauthenticated
+                when (val localResult = sessionLocalUserRepository.removeSavedUserInformation()) {
+                    is ResultListener.Failure -> {
+                        Log.e(TAG, "Local session cleanup failed after remote logout: ${localResult.message}")
+                        ResultListener.Failure(localResult.message)
+                    }
+
+                    is ResultListener.Success -> ResultListener.Success
+                }
+            }
+        }
+    }
+
+    private suspend fun resolveUserForSignOut(): UserInformation? {
+        sessionState.value.authenticatedUserOrNull?.let { return it }
+
+        val currentUid = firebaseAuthDataSource.currentUserUid() ?: return null
+        return when (val result = sessionRemoteUserRepository.fetchUserInformation(currentUid)) {
+            is AuthResultListener.Success -> result.userInformation
+            is AuthResultListener.Failure -> {
+                Log.w(TAG, "Fallback user fetch for sign out failed for uid=$currentUid: ${result.message}")
+                UserInformation(uid = currentUid)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/lifetogether/di/AppScope.kt
+++ b/app/src/main/java/com/example/lifetogether/di/AppScope.kt
@@ -1,0 +1,7 @@
+package com.example.lifetogether.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AppScope

--- a/app/src/main/java/com/example/lifetogether/di/SessionModule.kt
+++ b/app/src/main/java/com/example/lifetogether/di/SessionModule.kt
@@ -1,0 +1,48 @@
+package com.example.lifetogether.di
+
+import com.example.lifetogether.data.repository.SessionRepositoryImpl
+import com.example.lifetogether.data.repository.LocalUserRepositoryImpl
+import com.example.lifetogether.data.repository.RemoteUserRepositoryImpl
+import com.example.lifetogether.domain.repository.SessionLocalUserRepository
+import com.example.lifetogether.domain.repository.SessionRemoteUserRepository
+import com.example.lifetogether.domain.repository.SessionRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SessionScopeModule {
+    @Provides
+    @Singleton
+    @AppScope
+    fun provideAppScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SessionModule {
+    @Binds
+    @Singleton
+    abstract fun bindSessionRepository(
+        sessionRepositoryImpl: SessionRepositoryImpl,
+    ): SessionRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSessionRemoteUserRepository(
+        remoteUserRepositoryImpl: RemoteUserRepositoryImpl,
+    ): SessionRemoteUserRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSessionLocalUserRepository(
+        localUserRepositoryImpl: LocalUserRepositoryImpl,
+    ): SessionLocalUserRepository
+}

--- a/app/src/main/java/com/example/lifetogether/domain/model/session/SessionState.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/model/session/SessionState.kt
@@ -1,0 +1,16 @@
+package com.example.lifetogether.domain.model.session
+
+import com.example.lifetogether.domain.model.UserInformation
+
+sealed interface SessionState {
+    data object Loading : SessionState
+
+    data object Unauthenticated : SessionState
+
+    data class Authenticated(
+        val user: UserInformation,
+    ) : SessionState
+}
+
+val SessionState.authenticatedUserOrNull: UserInformation?
+    get() = (this as? SessionState.Authenticated)?.user

--- a/app/src/main/java/com/example/lifetogether/domain/repository/SessionLocalUserRepository.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/repository/SessionLocalUserRepository.kt
@@ -1,0 +1,7 @@
+package com.example.lifetogether.domain.repository
+
+import com.example.lifetogether.domain.listener.ResultListener
+
+interface SessionLocalUserRepository {
+    fun removeSavedUserInformation(): ResultListener
+}

--- a/app/src/main/java/com/example/lifetogether/domain/repository/SessionRemoteUserRepository.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/repository/SessionRemoteUserRepository.kt
@@ -1,0 +1,11 @@
+package com.example.lifetogether.domain.repository
+
+import com.example.lifetogether.domain.listener.AuthResultListener
+import com.example.lifetogether.domain.listener.ResultListener
+import kotlinx.coroutines.flow.Flow
+
+interface SessionRemoteUserRepository {
+    suspend fun logout(uid: String, familyId: String?): ResultListener
+    suspend fun fetchUserInformation(uid: String): AuthResultListener
+    fun observeUserInformation(uid: String): Flow<AuthResultListener>
+}

--- a/app/src/main/java/com/example/lifetogether/domain/repository/SessionRepository.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/repository/SessionRepository.kt
@@ -1,0 +1,11 @@
+package com.example.lifetogether.domain.repository
+
+import com.example.lifetogether.domain.listener.ResultListener
+import com.example.lifetogether.domain.model.session.SessionState
+import kotlinx.coroutines.flow.StateFlow
+
+interface SessionRepository {
+    val sessionState: StateFlow<SessionState>
+
+    suspend fun signOut(): ResultListener
+}

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/user/LogoutUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/user/LogoutUseCase.kt
@@ -1,13 +1,11 @@
 package com.example.lifetogether.domain.usecase.user
 
-import com.example.lifetogether.data.repository.RemoteUserRepositoryImpl
 import com.example.lifetogether.domain.listener.ResultListener
+import com.example.lifetogether.domain.repository.SessionRepository
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
-    private val remoteUserRepositoryImpl: RemoteUserRepositoryImpl,
+    private val sessionRepository: SessionRepository,
 ) {
-    suspend operator fun invoke(uid: String, familyId: String?): ResultListener {
-        return remoteUserRepositoryImpl.logout(uid, familyId)
-    }
+    suspend operator fun invoke(): ResultListener = sessionRepository.signOut()
 }

--- a/app/src/main/java/com/example/lifetogether/ui/feature/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/profile/ProfileScreen.kt
@@ -234,17 +234,12 @@ fun ProfileScreen(
             ProfileViewModel.ProfileConfirmationType.LOGOUT -> ConfirmationDialog(
                 onDismiss = { profileViewModel.closeConfirmationDialog() },
                 onConfirm = {
-                    userInformation?.uid?.let { uid ->
-                        profileViewModel.logout(
-                            uid,
-                            userInformation!!.familyId,
-                            onSuccess = {
-                                appSessionViewModel.onSignOut()
-                                profileViewModel.closeConfirmationDialog()
-                                appNavigator?.navigateToHome()
-                            },
-                        )
-                    }
+                    profileViewModel.logout(
+                        onSuccess = {
+                            profileViewModel.closeConfirmationDialog()
+                            appNavigator?.navigateToHome()
+                        },
+                    )
                 },
                 dialogTitle = "Logout",
                 dialogMessage = "Are you sure you want to logout?",

--- a/app/src/main/java/com/example/lifetogether/ui/feature/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/profile/ProfileViewModel.kt
@@ -46,12 +46,10 @@ class ProfileViewModel @Inject constructor(
 
     // ---------------------------------------------------------------- LOGOUT
     fun logout(
-        uid: String,
-        familyId: String?,
         onSuccess: () -> Unit,
     ) {
         viewModelScope.launch {
-            val result = logoutUseCase.invoke(uid, familyId)
+            val result = logoutUseCase.invoke()
             if (result is ResultListener.Success) {
                 println("ProfileViewModel: Logout successful")
                 onSuccess()


### PR DESCRIPTION
Summary
- introduce a singleton session boundary with SessionRepository and SessionState
- route profile logout through SessionRepository.signOut()
- add remote fetch/observe user-information helpers used by session initialization
- add session-scoped repository interfaces to avoid concrete coupling in SessionRepositoryImpl
- update phase execution flow rule: move active issue to In Progress before implementation starts

Verification
- JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home sh ./gradlew :app:compileDebugKotlin --stacktrace

Closes #2
