### PR TITLE
[Phase 2] [2.1] Define Result wrapper and AppError hierarchy

### DIFF
--- a/.ai/v2-plan/PhaseExecutionFlow.md
+++ b/.ai/v2-plan/PhaseExecutionFlow.md
@@ -24,11 +24,13 @@ This step must:
 - finalise the test cases as Markdown checkboxes (`- [ ]`)
 - answer all open questions in the phase file
 - update the phase file with the agreed decisions before proceeding
+- get explicit user approval for each important design decision branch; do not unilaterally finalise decision points in the phase file
 
 Required detail level:
 
 - each subphase should say not only what will be done, but how it should be implemented where that detail is already known
 - important boundary decisions, ownership decisions, lifecycle decisions, migration strategy decisions, and deletion decisions must be written into the phase file during grill-me rather than left implicit in chat history
+- when a decision is still under discussion, keep it clearly marked as pending/proposed in the phase file; only move it to final wording after explicit user agreement
 - if the conversation creates or changes a standing rule for future phase prep, update the relevant source-of-truth markdown file in `.ai/v2-plan/` during the same session
 - if a phase changes the current architecture or current implementation reality of the project, the implementation work for that phase must also update `Architecture.md` or another current-state project explainer so it reflects the new reality
 - historical implementation/phase/plan files must keep their historical references; do not remove old decisions or references from phase files just to make the current-state docs cleaner

--- a/.ai/v2-plan/phases/Phase02-DataLayer.md
+++ b/.ai/v2-plan/phases/Phase02-DataLayer.md
@@ -1,6 +1,6 @@
 # Phase 2 — Data Layer Deepening
 
-**Status:** Not started _(Not started → Grill-me in progress → Implementing → Complete)_
+**Status:** Grill-me in progress _(Not started → Grill-me in progress → Implementing → Complete)_
 
 ## Goal
 
@@ -22,42 +22,92 @@ Deepen the repository layer using a Ports & Adapters approach, introduce a funct
 - **Offline-First / SSOT mandate:** UI observes only the local database via `Flow`. When a refresh is requested, the repository fetches from network, saves to local DB, and finishes. ViewModels must never consume network data directly.
 - Delete passthrough use cases that do nothing but call a single repository method. ViewModels call repositories directly for simple operations. Use cases are reserved for complex/reused business logic only.
 - Logging cleanup: all `println(...)` in data and domain layers replaced with `Log.d(...)`.
+- Error model for Phase 2: one shared `AppError` hierarchy across domains.
+- Streaming contract default: `Flow<T>` for local observation + explicit `refresh()/write` commands returning `Result`.
+- `LocalDataSource` split strategy: full split in Phase 2; no new production callsites may depend on the god-object.
+- Passthrough use case policy: remove passthrough use cases in Phase 2 domains; keep only orchestration/business-rule use cases.
+- Rollout strategy: vertical domain slices.
+- Contract strictness: no temporary adapter layer for repository contracts in Phase 2; migrated slices must be fully strict on `Result`.
+- Logging strictness: full sweep of `println(...)` in `data/` and `domain/` during this phase.
 
 ## Subphases
 
-_To be finalised during the pre-implementation grill-me session._
-
-- [ ] 2.1 Define `Result<T, E>` sealed class and error hierarchy
-- [ ] 2.2 Split `LocalDataSource` into per-feature data sources
-- [ ] 2.3 Deepen repositories — move mapping logic in, enforce Offline-First pattern
-- [ ] 2.4 Update all repository return types to use `Result`
-- [ ] 2.5 Remove passthrough use cases; update ViewModel call sites
-- [ ] 2.6 Logging cleanup across data and domain layers
+- [ ] 2.1 Define phase-wide `Result<T, E>` and shared `AppError` hierarchy
+  - Create functional `Result` sealed class (`Success`, `Failure`) and shared `AppError`.
+  - Map expected Firebase/Room/IO failures into `AppError` instead of throwing.
+  - Define contract rules for one-shot commands vs streaming observations.
+- [ ] 2.2 Split `LocalDataSource` into feature-focused local data sources
+  - Decompose the current god-object local source into per-domain local sources.
+  - Rewire DI so repositories depend on focused local data sources.
+  - Do not add new production callsites to the old god-object local API.
+- [ ] 2.3 Deepen repositories with Offline-First / SSOT per vertical domain slice
+  - Reads exposed to UI observe local DB (`Flow<T>`).
+  - Refresh/write operations perform remote fetch + local persistence inside repositories and return `Result`.
+  - Mapping/orchestration logic moves from higher layers into repositories.
+  - Domain slices:
+    - lists/grocery
+    - recipes/guides
+    - gallery/tip-tracker/user-family
+- [ ] 2.4 Migrate repository contracts in migrated slices to strict `Result`
+  - Replace legacy listener-style repository contracts in migrated slices.
+  - No temporary adapter shims for repository boundaries in this phase.
+- [ ] 2.5 Remove passthrough use cases in migrated slices
+  - Remove use cases that only forward single repository calls.
+  - Rewire ViewModels to inject repositories directly where appropriate.
+  - Keep use cases that add orchestration/business rules.
+- [ ] 2.6 Logging cleanup in `data/` and `domain/`
+  - Replace `println(...)` with `Log.d/w/e` as appropriate.
+  - Keep tags consistent and avoid sensitive data in logs.
+- [ ] 2.7 Verification discipline for each issue slice
+  - Compile after each issue slice before commit.
+  - Run grep checks for `println(...)` and legacy contract leftovers.
+  - Keep issue/phase checkboxes aligned with implemented scope.
 
 ## Before Starting This Phase
 
 > **[Run `/grill-me`](../../skills/grill-me/grill-me.md)** with this file to stress-test the plan, finalise the subphases above, and fill in the sections below before writing any code.
 >
-> All **Open Questions** at the bottom of this file must be answered and the section removed before implementation begins.
+> Decision rule: important design decisions for this phase are only final after explicit user agreement in the grill-me session. Proposed options can be drafted, but they must stay marked as proposed until approved.
+>
+> Open questions for this phase have been resolved in grill-me. New decision branches discovered during implementation must be added here and explicitly approved before being marked final.
 
 ### Acceptance criteria
-_To be defined during the pre-implementation grill-me session._
+
+- [ ] Shared `Result<T, AppError>` contract is implemented and used in all Phase 2 migrated repository slices.
+- [ ] Shared `AppError` hierarchy is used for mapped expected failures in migrated slices.
+- [ ] `LocalDataSource` is split by feature domain with DI updated accordingly.
+- [ ] Migrated repository reads follow Offline-First/SSOT by observing local DB flows.
+- [ ] Refresh/write orchestration (remote + local persistence) is owned by repositories, not ViewModels/use cases.
+- [ ] Passthrough use cases in migrated slices are removed and call sites updated.
+- [ ] Repository boundaries in migrated slices no longer expose legacy listener wrappers.
+- [ ] `println(...)` is removed from `data/` and `domain/`.
 
 ### Test cases
-_To be defined during the pre-implementation grill-me session._
+
+- [ ] For at least one flow per migrated domain slice, local observation reflects remote refresh after repository persistence.
+- [ ] Expected repository failure paths return `Result.Failure(AppError)` without raw exception leaks.
+- [ ] ViewModel call sites compile and work after passthrough use case removals.
+- [ ] Repository contracts in migrated slices compile with strict `Result` signatures.
+- [ ] `rg "println\\(" app/src/main/java/com/example/lifetogether/data app/src/main/java/com/example/lifetogether/domain` returns no matches.
+- [ ] Compilation passes after each issue slice and at phase integration checkpoints.
 
 ## GitHub Issues
 
-Create milestone `Phase 2: Data Layer Deepening` and the following issues assigned to it:
+Milestone: `V2 Phase 2: Data Layer Deepening` (created)
 
-- `[Phase 2] Define Result wrapper and error hierarchy`
-- `[Phase 2] Data layer — <domain>` _(one per feature domain — confirm full list during grill-me)_
-- `[Phase 2] Remove passthrough use cases`
-- `[Phase 2] Logging cleanup — data and domain layers`
+Issue breakdown (agreed):
 
-> Pattern: one issue per feature domain for the repository deepening work. Update the domain list after the pre-implementation grill-me session.
+- `[Phase 2] [2.1] Define Result wrapper and AppError hierarchy` — issue #9
+- `[Phase 2] [2.2] Split LocalDataSource by feature domain and rewire DI` — issue #10
+- `[Phase 2] [2.3] Deepen lists/grocery repositories with Offline-First` — issue #11
+- `[Phase 2] [2.3] Deepen recipes/guides repositories with Offline-First` — issue #12
+- `[Phase 2] [2.3] Deepen gallery/tip-tracker/user-family repositories with Offline-First` — issue #13
+- `[Phase 2] [2.4-2.5] Migrate repository contracts to strict Result and remove passthrough use cases` — issue #14
+- `[Phase 2] [2.6-2.7] Logging cleanup and verification sweep` — issue #15
 
-## Open Questions
+Issue body requirements:
 
-- What should the error hierarchy look like — one sealed `AppError`, per-domain errors, or something else?
-- Should repositories expose `Flow<Result<T>>` for stream operations or only `Result<T>` for one-shot operations?
+- include scope/ownership
+- include issue-specific subphase checklist items from this file
+- include issue-specific acceptance criteria and test checklist items as checkboxes
+- include out-of-scope boundaries against other Phase 2 issues

--- a/.ai/v2-plan/phases/Phase05-ViewModelNormalization.md
+++ b/.ai/v2-plan/phases/Phase05-ViewModelNormalization.md
@@ -23,6 +23,8 @@ Normalise all feature ViewModels to expose a single `UiState` object for persist
 - Blocking confirmation state (e.g. delete confirmation dialogs currently rendered) may stay in `UiState` — it is part of the rendered UI.
 - Delete any remaining passthrough use cases encountered during this phase.
 - Logging cleanup: all `println(...)` in ViewModels and screens replaced with `Log.d(...)`.
+- We have some shared ViewModels like observer, notification and session which we should see if can be done in a better way
+- When making subphases and discussing the details for each subphase, we have to go through every ViewModel one for one to make sure we don't forget to refactor and normalise something
 
 ## Subphases
 

--- a/app/src/main/java/com/example/lifetogether/data/logic/AppErrorMapper.kt
+++ b/app/src/main/java/com/example/lifetogether/data/logic/AppErrorMapper.kt
@@ -1,0 +1,37 @@
+package com.example.lifetogether.data.logic
+
+import android.database.sqlite.SQLiteException
+import com.example.lifetogether.domain.result.AppError
+import com.google.firebase.FirebaseNetworkException
+import com.google.firebase.auth.FirebaseAuthException
+import com.google.firebase.auth.FirebaseAuthInvalidUserException
+import com.google.firebase.firestore.FirebaseFirestoreException
+import java.io.IOException
+import kotlinx.serialization.SerializationException
+
+fun Throwable.toAppError(): AppError {
+    val fallbackMessage = message ?: "Unknown error"
+    return when (this) {
+        is FirebaseNetworkException, is IOException -> AppError.Network(fallbackMessage)
+        is FirebaseAuthInvalidUserException, is FirebaseAuthException -> AppError.Authentication(fallbackMessage)
+        is FirebaseFirestoreException -> when (code) {
+            FirebaseFirestoreException.Code.PERMISSION_DENIED -> AppError.PermissionDenied(fallbackMessage)
+            FirebaseFirestoreException.Code.NOT_FOUND -> AppError.NotFound(fallbackMessage)
+            FirebaseFirestoreException.Code.ALREADY_EXISTS,
+            FirebaseFirestoreException.Code.ABORTED,
+            FirebaseFirestoreException.Code.FAILED_PRECONDITION,
+            -> AppError.Conflict(fallbackMessage)
+            FirebaseFirestoreException.Code.INVALID_ARGUMENT -> AppError.Validation(fallbackMessage)
+            FirebaseFirestoreException.Code.UNAVAILABLE,
+            FirebaseFirestoreException.Code.DEADLINE_EXCEEDED,
+            FirebaseFirestoreException.Code.RESOURCE_EXHAUSTED,
+            -> AppError.Network(fallbackMessage)
+            else -> AppError.Storage(fallbackMessage)
+        }
+
+        is SerializationException -> AppError.Serialization(fallbackMessage)
+        is IllegalArgumentException -> AppError.Validation(fallbackMessage)
+        is SQLiteException -> AppError.Storage(fallbackMessage)
+        else -> AppError.Unknown(fallbackMessage)
+    }
+}

--- a/app/src/main/java/com/example/lifetogether/data/logic/AppResult.kt
+++ b/app/src/main/java/com/example/lifetogether/data/logic/AppResult.kt
@@ -1,0 +1,18 @@
+package com.example.lifetogether.data.logic
+
+import com.example.lifetogether.domain.result.AppError
+import com.example.lifetogether.domain.result.Result
+
+inline fun <T> appResultOf(block: () -> T): Result<T, AppError> =
+    try {
+        Result.Success(block())
+    } catch (throwable: Throwable) {
+        Result.Failure(throwable.toAppError())
+    }
+
+suspend inline fun <T> appResultOfSuspend(crossinline block: suspend () -> T): Result<T, AppError> =
+    try {
+        Result.Success(block())
+    } catch (throwable: Throwable) {
+        Result.Failure(throwable.toAppError())
+    }

--- a/app/src/main/java/com/example/lifetogether/domain/result/AppError.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/result/AppError.kt
@@ -1,0 +1,15 @@
+package com.example.lifetogether.domain.result
+
+sealed interface AppError {
+    val message: String
+
+    data class Network(override val message: String) : AppError
+    data class Authentication(override val message: String) : AppError
+    data class PermissionDenied(override val message: String) : AppError
+    data class NotFound(override val message: String) : AppError
+    data class Conflict(override val message: String) : AppError
+    data class Validation(override val message: String) : AppError
+    data class Storage(override val message: String) : AppError
+    data class Serialization(override val message: String) : AppError
+    data class Unknown(override val message: String) : AppError
+}

--- a/app/src/main/java/com/example/lifetogether/domain/result/Result.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/result/Result.kt
@@ -1,0 +1,13 @@
+package com.example.lifetogether.domain.result
+
+/**
+ * Functional result type for one-shot data/domain operations.
+ *
+ * Contract for Phase 2:
+ * - one-shot commands/refresh operations return [Result]
+ * - stream observations are exposed as Flow<T> from local SSOT
+ */
+sealed interface Result<out T, out E> {
+    data class Success<T>(val data: T) : Result<T, Nothing>
+    data class Failure<E>(val error: E) : Result<Nothing, E>
+}


### PR DESCRIPTION
## Summary
- add shared functional Result<T, E> contract for one-shot data/domain operations
- add shared AppError hierarchy for mapped data/domain failures
- add Throwable-to-AppError mapper for Firebase/IO/Room/serialization/validation paths
- add helper wrappers for producing Result from sync/suspend command blocks

## Verification
- JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home sh ./gradlew :app:compileDebugKotlin --stacktrace

Relates to #9
