### PR TITLE
[Phase 2] Inject dispatchers in data and usecase layers

### DIFF
--- a/app/src/main/java/com/example/lifetogether/data/local/source/MediaLocalDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/local/source/MediaLocalDataSource.kt
@@ -10,6 +10,7 @@ import com.example.lifetogether.data.local.dao.GalleryMediaDao
 import com.example.lifetogether.data.logic.generateImageThumbnailFromFile
 import com.example.lifetogether.data.logic.generateVideoThumbnailFromFile
 import com.example.lifetogether.data.model.GalleryMediaEntity
+import com.example.lifetogether.di.IoDispatcher
 import com.example.lifetogether.domain.result.Result
 import com.example.lifetogether.domain.model.enums.MediaType
 import com.example.lifetogether.domain.model.gallery.GalleryImage
@@ -17,7 +18,7 @@ import com.example.lifetogether.domain.model.gallery.GalleryMedia
 import com.example.lifetogether.domain.model.gallery.GalleryVideo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -27,6 +28,7 @@ import javax.inject.Singleton
 class MediaLocalDataSource @Inject constructor(
     @ApplicationContext private val context: Context,
     private val galleryMediaDao: GalleryMediaDao,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     companion object {
         private const val TAG = "MediaLocalDataSource"
@@ -259,7 +261,7 @@ class MediaLocalDataSource @Inject constructor(
         val entity = galleryMediaDao.getItemByIdDirect(mediaId) ?: return null
         val mediaUri = entity.mediaUri?.toUri() ?: return null
 
-        val tempFile = withContext(Dispatchers.IO) {
+        val tempFile = withContext(ioDispatcher) {
             File.createTempFile("thumb_regen_", "tmp", context.cacheDir)
         }
         return try {

--- a/app/src/main/java/com/example/lifetogether/data/local/source/MediaLocalDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/local/source/MediaLocalDataSource.kt
@@ -26,9 +26,9 @@ import javax.inject.Singleton
 
 @Singleton
 class MediaLocalDataSource @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val galleryMediaDao: GalleryMediaDao,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     companion object {
         private const val TAG = "MediaLocalDataSource"

--- a/app/src/main/java/com/example/lifetogether/data/local/source/SessionCleanupLocalDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/local/source/SessionCleanupLocalDataSource.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 
 @Singleton
 class SessionCleanupLocalDataSource @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val groceryListDao: GroceryListDao,
     private val recipesDao: RecipesDao,
     private val userInformationDao: UserInformationDao,

--- a/app/src/main/java/com/example/lifetogether/data/logic/ImageProcessor.kt
+++ b/app/src/main/java/com/example/lifetogether/data/logic/ImageProcessor.kt
@@ -23,7 +23,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class ImageProcessor @Inject constructor(
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
     companion object {

--- a/app/src/main/java/com/example/lifetogether/data/logic/ImageProcessor.kt
+++ b/app/src/main/java/com/example/lifetogether/data/logic/ImageProcessor.kt
@@ -8,9 +8,10 @@ import android.net.Uri
 import android.util.Log
 import coil.ImageLoader
 import coil.request.ImageRequest
+import com.example.lifetogether.di.IoDispatcher
 import com.example.lifetogether.domain.model.sealed.ImageType
 import com.example.lifetogether.util.Constants
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import javax.inject.Inject
@@ -21,7 +22,9 @@ import javax.inject.Singleton
  * Extracted from data sources to follow Single Responsibility Principle.
  */
 @Singleton
-class ImageProcessor @Inject constructor() {
+class ImageProcessor @Inject constructor(
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
 
     companion object {
         private const val TAG = "ImageProcessor"
@@ -40,7 +43,7 @@ class ImageProcessor @Inject constructor() {
         imageType: ImageType,
         context: Context,
     ): ProcessedImage? {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             try {
                 // Get path and processing parameters based on image type
                 val config = getImageConfig(imageType) ?: return@withContext null
@@ -118,7 +121,7 @@ class ImageProcessor @Inject constructor() {
         maxWidth: Int,
         maxHeight: Int,
     ): Bitmap? {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             try {
                 // First decode bounds to calculate inSampleSize
                 val options = BitmapFactory.Options().apply {

--- a/app/src/main/java/com/example/lifetogether/data/remote/CloudflareR2StorageDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/remote/CloudflareR2StorageDataSource.kt
@@ -16,10 +16,11 @@ import aws.smithy.kotlin.runtime.content.writeToFile
 import aws.smithy.kotlin.runtime.net.url.Url
 import com.example.lifetogether.BuildConfig
 import com.example.lifetogether.data.logic.ImageProcessor
+import com.example.lifetogether.di.IoDispatcher
 import com.example.lifetogether.domain.result.Result
 import com.example.lifetogether.domain.model.sealed.ImageType
 import com.example.lifetogether.domain.datasource.StorageDataSource
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -32,6 +33,7 @@ import androidx.core.net.toUri
 class CloudflareR2StorageDataSource @Inject constructor(
     private val application: Application,
     private val imageProcessor: ImageProcessor,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : StorageDataSource {
 
     companion object {
@@ -145,7 +147,7 @@ class CloudflareR2StorageDataSource @Inject constructor(
             }
 
             val deferredResults = urlList.map { url ->
-                async(Dispatchers.IO) {
+                async(ioDispatcher) {
                     deleteImage(url)
                 }
             }
@@ -177,7 +179,7 @@ class CloudflareR2StorageDataSource @Inject constructor(
             val objectKey = "$path/$fileName"
 
             // Open and use input stream, ensuring it's closed after upload
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 application.contentResolver.openInputStream(uri)?.use { videoStream ->
                     // Stream video upload to avoid loading entire file into memory
                     val putObjectRequest = PutObjectRequest {

--- a/app/src/main/java/com/example/lifetogether/data/remote/CloudflareR2StorageDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/remote/CloudflareR2StorageDataSource.kt
@@ -33,7 +33,7 @@ import androidx.core.net.toUri
 class CloudflareR2StorageDataSource @Inject constructor(
     private val application: Application,
     private val imageProcessor: ImageProcessor,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : StorageDataSource {
 
     companion object {

--- a/app/src/main/java/com/example/lifetogether/data/repository/GalleryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/lifetogether/data/repository/GalleryRepositoryImpl.kt
@@ -43,7 +43,7 @@ class GalleryRepositoryImpl @Inject constructor(
     private val mediaLocalDataSource: MediaLocalDataSource,
     private val galleryFirestoreDataSource: GalleryFirestoreDataSource,
     private val storageDataSource: StorageDataSource,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : GalleryRepository {
 
     companion object {

--- a/app/src/main/java/com/example/lifetogether/data/repository/GalleryRepositoryImpl.kt
+++ b/app/src/main/java/com/example/lifetogether/data/repository/GalleryRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.example.lifetogether.data.local.source.AlbumLocalDataSource
 import com.example.lifetogether.data.local.source.MediaLocalDataSource
 import com.example.lifetogether.data.model.AlbumEntity
 import com.example.lifetogether.data.remote.GalleryFirestoreDataSource
+import com.example.lifetogether.di.IoDispatcher
 import com.example.lifetogether.domain.result.Result
 import com.example.lifetogether.domain.model.SaveProgress
 import com.example.lifetogether.domain.model.enums.MediaType
@@ -25,8 +26,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -42,6 +43,7 @@ class GalleryRepositoryImpl @Inject constructor(
     private val mediaLocalDataSource: MediaLocalDataSource,
     private val galleryFirestoreDataSource: GalleryFirestoreDataSource,
     private val storageDataSource: StorageDataSource,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : GalleryRepository {
 
     companion object {
@@ -236,7 +238,7 @@ class GalleryRepositoryImpl @Inject constructor(
                             coroutineScope {
                                 val semaphore = Semaphore(MAX_CONCURRENT_DOWNLOADS)
                                 val downloadTasks: List<Deferred<Pair<GalleryMedia, File>?>> = batch.map { galleryMedia ->
-                                    async(Dispatchers.IO) {
+                                    async(ioDispatcher) {
                                         semaphore.acquire()
                                         try {
                                             galleryMedia.mediaUrl?.let { url ->

--- a/app/src/main/java/com/example/lifetogether/di/DispatcherModule.kt
+++ b/app/src/main/java/com/example/lifetogether/di/DispatcherModule.kt
@@ -1,0 +1,29 @@
+package com.example.lifetogether.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatcherModule {
+
+    @Provides
+    @Singleton
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @Singleton
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @Singleton
+    @MainDispatcher
+    fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+}

--- a/app/src/main/java/com/example/lifetogether/di/DispatcherQualifiers.kt
+++ b/app/src/main/java/com/example/lifetogether/di/DispatcherQualifiers.kt
@@ -1,0 +1,15 @@
+package com.example.lifetogether.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class MainDispatcher

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/image/UploadGalleryMediaItemsUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/image/UploadGalleryMediaItemsUseCase.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
 class UploadGalleryMediaItemsUseCase @Inject constructor(
     private val imageRepository: ImageRepository,
     private val galleryRepository: GalleryRepository,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     companion object {
         // Limit to 1 concurrent upload - AWS SDK buffers request bodies for checksums

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/image/UploadGalleryMediaItemsUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/image/UploadGalleryMediaItemsUseCase.kt
@@ -4,6 +4,7 @@ import android.content.ContentValues.TAG
 import android.content.Context
 import android.provider.MediaStore
 import android.util.Log
+import com.example.lifetogether.di.IoDispatcher
 import com.example.lifetogether.domain.model.gallery.GalleryImage
 import com.example.lifetogether.domain.model.gallery.GalleryMedia
 import com.example.lifetogether.domain.model.gallery.GalleryVideo
@@ -13,8 +14,8 @@ import com.example.lifetogether.domain.repository.ImageRepository
 import com.example.lifetogether.domain.model.sealed.ImageType
 import com.example.lifetogether.domain.result.Result
 import com.example.lifetogether.util.Constants
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -24,6 +25,7 @@ import javax.inject.Inject
 class UploadGalleryMediaItemsUseCase @Inject constructor(
     private val imageRepository: ImageRepository,
     private val galleryRepository: GalleryRepository,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     companion object {
         // Limit to 1 concurrent upload - AWS SDK buffers request bodies for checksums
@@ -77,7 +79,7 @@ class UploadGalleryMediaItemsUseCase @Inject constructor(
         val processedResults: List<Pair<GalleryMedia?, String?>> = coroutineScope {
             val semaphore = Semaphore(MAX_CONCURRENT_UPLOADS)
             val deferredTasks: List<Deferred<Pair<GalleryMedia?, String?>>> = mediaUploadList.map { mediaData ->
-                async(Dispatchers.IO) { // Each async block will return Pair(GalleryMedia_on_success_OR_null, error_message_string_OR_null)
+                async(ioDispatcher) { // Each async block will return Pair(GalleryMedia_on_success_OR_null, error_message_string_OR_null)
                     semaphore.acquire()
                     try {
                         val (mediaType, uri, extension) = Triple(mediaData.mediaType, mediaData.uri, mediaData.extension)


### PR DESCRIPTION
Implements issue #25 by replacing hardcoded coroutine dispatcher usage in targeted data/usecase code paths.

Changes:
- Added dispatcher qualifiers: `@IoDispatcher`, `@DefaultDispatcher`, `@MainDispatcher`
- Added `DispatcherModule` providers for coroutine dispatchers
- Replaced direct `Dispatchers.IO` usages with injected `@IoDispatcher` in targeted classes
- Applied `@param:` target to qualifier injections (`@param:IoDispatcher`, `@param:ApplicationContext`) to avoid KT-73255 warning ambiguity

Verification:
- `:app:compileDebugKotlin` passes
- `rg -n "Dispatchers\.IO" app/src/main/java/com/example/lifetogether/data app/src/main/java/com/example/lifetogether/domain/usecase` returns no matches

Relates to #25
