### PR TITLE
[Phase 2] Standardize logging in data/usecase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -253,8 +253,54 @@ tasks.register("verifyNoStringResultInDataDomain") {
     }
 }
 
+tasks.register("verifyNoPrintlnInDataUsecase") {
+    group = "verification"
+    description = "Fails if println(...) is used in data/ or domain/usecase source sets."
+
+    doLast {
+        val pattern = Regex("""\bprintln\s*\(""")
+        val roots =
+            listOf(
+                File(projectDir, "src/main/java/com/example/lifetogether/data"),
+                File(projectDir, "src/main/java/com/example/lifetogether/domain/usecase"),
+            )
+
+        val violations =
+            roots
+                .filter { it.exists() }
+                .flatMap { root ->
+                    root
+                        .walkTopDown()
+                        .filter { it.isFile && it.extension == "kt" }
+                        .flatMap { file ->
+                            file
+                                .readLines()
+                                .mapIndexedNotNull { index, line ->
+                                    if (pattern.containsMatchIn(line)) {
+                                        "${file.relativeTo(projectDir).path}:${index + 1}: $line"
+                                    } else {
+                                        null
+                                    }
+                                }
+                                .toList()
+                        }
+                        .toList()
+                }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("Found forbidden println(...) usage in data/domain-usecase:")
+                    violations.forEach { appendLine(it) }
+                },
+            )
+        }
+    }
+}
+
 tasks.named("check") {
     dependsOn("verifyNoStringResultInDataDomain")
+    dependsOn("verifyNoPrintlnInDataUsecase")
 }
 
 afterEvaluate {

--- a/app/src/main/java/com/example/lifetogether/data/remote/FirebaseAuthDataSource.kt
+++ b/app/src/main/java/com/example/lifetogether/data/remote/FirebaseAuthDataSource.kt
@@ -5,6 +5,7 @@ import com.example.lifetogether.data.logic.appResultOfSuspend
 
 import com.example.lifetogether.domain.result.AppError
 
+import android.util.Log
 import com.example.lifetogether.domain.result.Result
 import com.example.lifetogether.domain.model.User
 import com.example.lifetogether.domain.model.UserInformation
@@ -20,10 +21,14 @@ import javax.inject.Inject
 class FirebaseAuthDataSource@Inject constructor(
     private val familyFirestoreDataSource: FamilyFirestoreDataSource,
 ) {
+    private companion object {
+        const val TAG = "FirebaseAuthDS"
+    }
+
     suspend fun login(
         user: User,
     ): Result<UserInformation, AppError> {
-        println("FirebaseAuthDataSource login()")
+        Log.d(TAG, "login start")
         return appResultOfSuspend {
             val loginResult = Firebase.auth.signInWithEmailAndPassword(user.email, user.password).await()
             val firebaseUser = loginResult.user
@@ -39,12 +44,11 @@ class FirebaseAuthDataSource@Inject constructor(
         user: User,
         userInformation: UserInformation,
     ): Result<UserInformation, AppError> {
-        println("FirebaseAuthDataSource signUp()")
+        Log.d(TAG, "signUp start")
         return appResultOfSuspend {
             val signupResult = Firebase.auth.createUserWithEmailAndPassword(user.email, user.password).await()
             val firebaseUser = signupResult.user
-            println("signupResult: $signupResult")
-            println("firebaseUser: $firebaseUser")
+            Log.d(TAG, "signUp auth response received")
             if (firebaseUser != null) {
                 userInformation.copy(uid = firebaseUser.uid)
             } else {
@@ -78,7 +82,7 @@ class FirebaseAuthDataSource@Inject constructor(
     ): Result<Unit, AppError> {
         return appResultOfSuspend {
             FirebaseAuth.getInstance().signOut()
-            println("datasource logout result: ${FirebaseAuth.getInstance().currentUser}")
+            Log.d(TAG, "logout signOut completed")
             if (familyId != null) {
                 familyFirestoreDataSource.removeDeviceToken(uid, familyId)
             }

--- a/app/src/main/java/com/example/lifetogether/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/lifetogether/data/repository/UserRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.example.lifetogether.data.logic.appResultOfSuspend
 
 import com.example.lifetogether.domain.result.AppError
 
+import android.util.Log
 import com.example.lifetogether.data.local.source.SessionCleanupLocalDataSource
 import com.example.lifetogether.data.local.source.UserLocalDataSource
 import com.example.lifetogether.data.remote.FamilyFirestoreDataSource
@@ -33,12 +34,15 @@ class UserRepositoryImpl @Inject constructor(
     private val familyFirestoreDataSource: FamilyFirestoreDataSource,
     private val storageDataSource: StorageDataSource,
 ) : UserRepository, SessionUserRepository {
+    private companion object {
+        const val TAG = "UserRepositoryImpl"
+    }
 
     fun getFamilyInformation(familyId: String): Flow<Result<FamilyInformation, AppError>> {
         // Get family information (without members)
         val familyInformationFlow: Flow<Result<FamilyInformation, AppError>> = userLocalDataSource.getFamilyInformation(familyId).map { user ->
             appResultOf {
-                println("LocalUserRepositoryImpl getFamilyInformation user: $user")
+                Log.d(TAG, "Mapping family information from local user record")
 
                 // Initial FamilyInformation without members
                 FamilyInformation(
@@ -51,14 +55,14 @@ class UserRepositoryImpl @Inject constructor(
         val familyMembersFlow = userLocalDataSource.getFamilyMembers(familyId).map { list ->
             list.map { familyMember ->
                 try {
-                    println("LocalUserRepositoryImpl getFamilyInformation familyMember: $familyMember")
+                    Log.d(TAG, "Mapping local family member")
 
                     FamilyMember(
                         uid = familyMember.uid,
                         name = familyMember.name,
                     )
                 } catch (e: Exception) {
-                    println("Error fetching family members: ${e.message}")
+                    Log.e(TAG, "Failed mapping family member: ${e.message}", e)
                     emptyList<FamilyMember>()
                 }
             }
@@ -87,7 +91,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun login(
         user: User,
     ): Result<UserInformation, AppError> {
-        println("RemoteUserRepositoryImpl login()")
+        Log.d(TAG, "login start")
         return firebaseAuthDataSource.login(user)
     }
 
@@ -95,21 +99,21 @@ class UserRepositoryImpl @Inject constructor(
         user: User,
         userInformation: UserInformation,
     ): Result<UserInformation, AppError> {
-        println("RemoteUserRepositoryImpl signUp()")
+        Log.d(TAG, "signUp start")
         return appResultOfSuspend {
             val signupResult = firebaseAuthDataSource.signUp(user, userInformation)
-            println("RemoteUserRepositoryImpl signupResult: $signupResult")
+            Log.d(TAG, "signUp auth response received")
             val signedUpUser = when (signupResult) {
                 is Result.Success -> signupResult.data
                 is Result.Failure -> throw AppErrorThrowable(signupResult.error)
             }
             when (val uploadResult = userFirestoreDataSource.uploadUserInformation(signedUpUser)) {
                 is Result.Success -> {
-                    println("RemoteUserRepositoryImpl: uploadResult $uploadResult")
+                    Log.d(TAG, "signUp user info upload succeeded")
                     signedUpUser
                 }
                 is Result.Failure -> {
-                    println("RemoteUserRepositoryImpl: uploadResult $uploadResult")
+                    Log.e(TAG, "signUp user info upload failed: ${uploadResult.error}")
                     throw AppErrorThrowable(uploadResult.error)
                 }
             }
@@ -203,7 +207,7 @@ class UserRepositoryImpl @Inject constructor(
         uid: String,
         name: String,
     ): Result<Unit, AppError> {
-        println("RemoteUserRepositoryImpl joinFamily()")
+        Log.d(TAG, "joinFamily start")
         when (val result = familyFirestoreDataSource.joinFamily(familyId, uid, name)) {
             is Result.Success -> {
                 val updateResult = userFirestoreDataSource.updateFamilyId(uid, familyId)
@@ -219,7 +223,7 @@ class UserRepositoryImpl @Inject constructor(
         uid: String,
         name: String,
     ): Result<Unit, AppError> {
-        println("RemoteUserRepositoryImpl createNewFamily()")
+        Log.d(TAG, "createNewFamily start")
         when (val result = familyFirestoreDataSource.createNewFamily(uid, name)) {
             is Result.Success -> {
                 val updateResult = userFirestoreDataSource.updateFamilyId(uid, result.data)
@@ -235,7 +239,7 @@ class UserRepositoryImpl @Inject constructor(
         familyId: String,
         uid: String,
     ): Result<Unit, AppError> {
-        println("RemoteUserRepositoryImpl leaveFamily()")
+        Log.d(TAG, "leaveFamily start")
         when (val result = familyFirestoreDataSource.leaveFamily(familyId, uid)) {
             is Result.Success -> {
                 val updateResult = userFirestoreDataSource.updateFamilyId(uid, null)
@@ -250,7 +254,7 @@ class UserRepositoryImpl @Inject constructor(
     suspend fun deleteFamily(
         familyId: String,
     ): Result<Unit, AppError> {
-        println("RemoteUserRepositoryImpl deleteFamily()")
+        Log.d(TAG, "deleteFamily start")
         return familyFirestoreDataSource.deleteFamily(familyId)
     }
 

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/image/UploadImageUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/image/UploadImageUseCase.kt
@@ -4,6 +4,7 @@ import com.example.lifetogether.domain.result.AppError
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import com.example.lifetogether.domain.model.sealed.ImageType
 import com.example.lifetogether.domain.repository.ImageRepository
 import com.example.lifetogether.domain.result.Result
@@ -12,18 +13,22 @@ import javax.inject.Inject
 class UploadImageUseCase @Inject constructor(
     private val imageRepository: ImageRepository,
 ) {
+    private companion object {
+        const val TAG = "UploadImageUseCase"
+    }
+
     suspend operator fun invoke(
         uri: Uri,
         imageType: ImageType,
         context: Context,
     ): Result<Unit, AppError> {
-        println("UploadImageUseCase uri: $uri")
+        Log.d(TAG, "invoke")
         val firebaseStorageResult = imageRepository.uploadImage(uri, imageType, context)
-        println("UploadImageUseCase firebaseStorageResult: $firebaseStorageResult")
+        Log.d(TAG, "uploadImage completed")
         when (firebaseStorageResult) {
             is Result.Success -> {
                 val url = firebaseStorageResult.data
-                println("UploadImageUseCase image download url: $url")
+                Log.d(TAG, "image upload returned url; updating references")
                 val firestoreDeleteOldImageResult = imageRepository.deleteImage(imageType)
 
                 val firestoreNewUrlResult = imageRepository.saveImageDownloadUrl(url, imageType)

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveAlbumsUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveAlbumsUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.GalleryRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +11,10 @@ import javax.inject.Inject
 class ObserveAlbumsUseCase @Inject constructor(
     private val galleryRepository: GalleryRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveAlbumsUC"
+    }
+
     fun start(
         scope: CoroutineScope,
         familyId: String,
@@ -19,7 +24,7 @@ class ObserveAlbumsUseCase @Inject constructor(
             galleryRepository.syncAlbumsFromRemote(familyId).collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("albums sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "albums sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveCategoriesUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveCategoriesUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.CategoryRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,13 +11,17 @@ import javax.inject.Inject
 class ObserveCategoriesUseCase @Inject constructor(
     private val categoryRepository: CategoryRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveCategoriesUC"
+    }
+
     fun start(scope: CoroutineScope): ObserverStartHandle {
         val firstSuccess = CompletableDeferred<kotlin.Result<Unit>>()
         val job = scope.launch {
             categoryRepository.syncCategoriesFromRemote().collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("categories sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "categories sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveFamilyInformationUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveFamilyInformationUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.FamilyRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +11,10 @@ import javax.inject.Inject
 class ObserveFamilyInformationUseCase @Inject constructor(
     private val familyRepository: FamilyRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveFamilyInfoUC"
+    }
+
     fun start(
         scope: CoroutineScope,
         familyId: String,
@@ -19,7 +24,7 @@ class ObserveFamilyInformationUseCase @Inject constructor(
             familyRepository.syncFamilyInformationFromRemote(familyId).collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("family info sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "family info sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveGroceryListUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveGroceryListUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.GroceryRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +11,10 @@ import javax.inject.Inject
 class ObserveGroceryListUseCase @Inject constructor(
     private val groceryRepository: GroceryRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveGroceryListUC"
+    }
+
     fun start(
         scope: CoroutineScope,
         familyId: String,
@@ -19,7 +24,7 @@ class ObserveGroceryListUseCase @Inject constructor(
             groceryRepository.syncGroceryItemsFromRemote(familyId).collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("grocery list sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "grocery list sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveGrocerySuggestionsUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveGrocerySuggestionsUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.GroceryRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,13 +11,17 @@ import javax.inject.Inject
 class ObserveGrocerySuggestionsUseCase @Inject constructor(
     private val groceryRepository: GroceryRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveGrocerySuggUC"
+    }
+
     fun start(scope: CoroutineScope): ObserverStartHandle {
         val firstSuccess = CompletableDeferred<kotlin.Result<Unit>>()
         val job = scope.launch {
             groceryRepository.syncGrocerySuggestionsFromRemote().collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("grocery suggestions sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "grocery suggestions sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveRecipesUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveRecipesUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.RecipeRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +11,10 @@ import javax.inject.Inject
 class ObserveRecipesUseCase @Inject constructor(
     private val recipeRepository: RecipeRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveRecipesUC"
+    }
+
     fun start(
         scope: CoroutineScope,
         familyId: String,
@@ -19,7 +24,7 @@ class ObserveRecipesUseCase @Inject constructor(
             recipeRepository.syncRecipesFromRemote(familyId).collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("recipes sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "recipes sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveTipTrackerUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveTipTrackerUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.TipTrackerRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +11,10 @@ import javax.inject.Inject
 class ObserveTipTrackerUseCase @Inject constructor(
     private val tipTrackerRepository: TipTrackerRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveTipTrackerUC"
+    }
+
     fun start(
         scope: CoroutineScope,
         familyId: String,
@@ -19,7 +24,7 @@ class ObserveTipTrackerUseCase @Inject constructor(
             tipTrackerRepository.syncTipsFromRemote(familyId).collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("tip sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "tip sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveUserInformationUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/observers/ObserveUserInformationUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.lifetogether.domain.usecase.observers
 
+import android.util.Log
 import com.example.lifetogether.domain.repository.UserRepository
 import com.example.lifetogether.domain.result.Result as AppResult
 import kotlinx.coroutines.CompletableDeferred
@@ -10,6 +11,10 @@ import javax.inject.Inject
 class ObserveUserInformationUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
+    private companion object {
+        const val TAG = "ObserveUserInfoUC"
+    }
+
     fun start(
         scope: CoroutineScope,
         uid: String,
@@ -19,7 +24,7 @@ class ObserveUserInformationUseCase @Inject constructor(
             userRepository.syncUserInformationFromRemote(uid).collect { result ->
                 when (result) {
                     is AppResult.Success -> firstSuccess.completeFirstSuccessIfNeeded()
-                    is AppResult.Failure -> println("user info sync failure: ${result.error}")
+                    is AppResult.Failure -> Log.e(TAG, "user info sync failure: ${result.error}")
                 }
             }
         }

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/user/LoginUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/user/LoginUseCase.kt
@@ -2,6 +2,7 @@ package com.example.lifetogether.domain.usecase.user
 
 import com.example.lifetogether.domain.result.AppError
 
+import android.util.Log
 import com.example.lifetogether.domain.model.User
 import com.example.lifetogether.domain.model.UserInformation
 import com.example.lifetogether.domain.repository.UserRepository
@@ -11,8 +12,12 @@ import javax.inject.Inject
 class LoginUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
+    private companion object {
+        const val TAG = "LoginUseCase"
+    }
+
     suspend operator fun invoke(user: User): Result<UserInformation, AppError> {
-        println("LoginUseCase invoked")
+        Log.d(TAG, "invoke")
         // TODO Handle the login logic and validation here
 //        val userValidationUseCase = UserValidationUseCase()
 //

--- a/app/src/main/java/com/example/lifetogether/domain/usecase/user/SignUpUseCase.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/usecase/user/SignUpUseCase.kt
@@ -2,6 +2,7 @@ package com.example.lifetogether.domain.usecase.user
 
 import com.example.lifetogether.domain.result.AppError
 
+import android.util.Log
 import com.example.lifetogether.domain.model.User
 import com.example.lifetogether.domain.model.UserInformation
 import com.example.lifetogether.domain.repository.UserRepository
@@ -11,6 +12,10 @@ import javax.inject.Inject
 class SignUpUseCase @Inject constructor(
     private val userRepository: UserRepository,
 ) {
+    private companion object {
+        const val TAG = "SignUpUseCase"
+    }
+
     suspend operator fun invoke(
         user: User,
         userInformation: UserInformation,
@@ -36,7 +41,7 @@ class SignUpUseCase @Inject constructor(
 //            error = "Invalid email."
 //            return
 //        }
-        println("SignUpUseCase invoked")
+        Log.d(TAG, "invoke")
         return userRepository.signUp(user, userInformation)
     }
 }


### PR DESCRIPTION
## Summary
- replace `println(...)` usage in `data/` + `domain/usecase/` with structured `Log` calls
- standardize logging tags across touched classes
- avoid logging sensitive payloads by logging lifecycle/status messages instead of full objects
- add Gradle guard task `verifyNoPrintlnInDataUsecase` to prevent regressions

## Verification
- `:app:verifyNoPrintlnInDataUsecase`
- `:app:compileDebugKotlin`
- `rg -n "println\\(" app/src/main/java/com/example/lifetogether/data app/src/main/java/com/example/lifetogether/domain/usecase -S` (no matches)

Relates to #27
