### PR TITLE
[Phase 2] Logging cleanup and verification sweep

### DIFF
--- a/app/src/main/java/com/example/lifetogether/domain/logic/copyToClipboard.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/logic/copyToClipboard.kt
@@ -3,10 +3,13 @@ package com.example.lifetogether.domain.logic
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.util.Log
+
+private const val TAG = "ClipboardUtils"
 
 fun copyToClipboard(context: Context, text: String) {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     val clip = ClipData.newPlainText("LifeTogether Copied Text", text)
     clipboard.setPrimaryClip(clip)
-    println("Text copied to clipboard: $text")
+    Log.d(TAG, "Text copied to clipboard")
 }

--- a/app/src/main/java/com/example/lifetogether/domain/logic/getServiceAccountAccessToken.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/logic/getServiceAccountAccessToken.kt
@@ -1,11 +1,14 @@
 package com.example.lifetogether.domain.logic
 
 import android.content.Context
+import android.util.Log
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.auth.oauth2.ServiceAccountCredentials
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.InputStream
+
+private const val TAG = "ServiceAccountAuth"
 
 suspend fun getServiceAccountAccessToken(context: Context): GoogleCredentials? = withContext(Dispatchers.IO) {
     try {
@@ -14,17 +17,14 @@ suspend fun getServiceAccountAccessToken(context: Context): GoogleCredentials? =
         val credentials = ServiceAccountCredentials
             .fromStream(inputStream)
             .createScoped(listOf("https://www.googleapis.com/auth/firebase.messaging"))
-
-        println("Credentials: $credentials")
+        Log.d(TAG, "Service account credentials loaded")
 
         // Refresh the access token on a background thread
         // credentials.refreshAccessToken() // Removed this line
 
         return@withContext credentials
     } catch (e: Exception) {
-        println("Error loading service account credentials: ${e.message}")
-        e.printStackTrace()
-        println("Exception type: ${e::class.java.name}") // Print the type of exception
+        Log.e(TAG, "Error loading service account credentials: ${e.message}", e)
         return@withContext null
     }
 }

--- a/app/src/main/java/com/example/lifetogether/domain/logic/sendFCMNotification.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/logic/sendFCMNotification.kt
@@ -1,6 +1,7 @@
 package com.example.lifetogether.domain.logic
 
 import android.content.Context
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.example.lifetogether.R
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
@@ -17,6 +18,8 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 
+private const val TAG = "SendFcmNotification"
+
 suspend fun sendFCMNotification(
     context: Context,
     tokens: List<String>,
@@ -29,11 +32,11 @@ suspend fun sendFCMNotification(
     autoCancel: Boolean = true,
     destination: String? = null,
 ) = withContext(Dispatchers.IO) {
-    println("sendFCMNotification trying to get credentials")
+    Log.d(TAG, "Preparing to send notifications. tokenCount=${tokens.size}")
     val credentials = getServiceAccountAccessToken(context)
 
     if (credentials == null) {
-        println("Failed to get service account credentials")
+        Log.e(TAG, "Failed to get service account credentials")
         return@withContext
     }
 
@@ -57,7 +60,7 @@ suspend fun sendFCMNotification(
     var i = 0
     for (token in tokens) {
         i += 1
-        println("Sending notification to token $i of ${tokens.size}: $token")
+        Log.d(TAG, "Sending notification to token $i of ${tokens.size}")
 
         val requestBody = buildJsonObject {
             putJsonObject("message") {
@@ -89,9 +92,9 @@ suspend fun sendFCMNotification(
 
         // Check response
         if (response.statusCode == 200) {
-            println("Notification sent successfully!")
+            Log.d(TAG, "Notification sent successfully for token $i")
         } else {
-            println("Failed to send notification: ${response.statusCode}")
+            Log.e(TAG, "Failed to send notification for token $i: status=${response.statusCode}")
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace remaining `println(...)` in `domain/logic` with Android `Log` APIs
- align log levels/messages with existing structured logging style
- avoid logging sensitive runtime content (clipboard text, tokens, full credentials)

## Verification
- `rg "println\\(" app/src/main/java/com/example/lifetogether/data app/src/main/java/com/example/lifetogether/domain` (no matches)
- `rg "Result<.*?,\\s*String>|ResultListener|AuthResultListener|ListItemsResultListener|ListQueryLocalDataSource|ListQueryTypeMapper|ListQueryType\\b" app/src/main/java/com/example/lifetogether/data app/src/main/java/com/example/lifetogether/domain` (no matches)
- `:app:compileDebugKotlin`

Relates to #15
