### PR TITLE
- Removed the exposed sync-state flows and first-success tracking fro…

### DIFF
--- a/.ai/v2-plan/phases/Phase09-MotionLoadingInteraction.md
+++ b/.ai/v2-plan/phases/Phase09-MotionLoadingInteraction.md
@@ -212,15 +212,11 @@ _To be finalised during the pre-implementation grill-me session._
 
 ## GitHub Issues
 
-Create milestone `Phase 9: Motion, Loading & Interaction Patterns` and the following issues assigned to it:
+Create milestone `V2 Phase 9: Motion, Loading & Interaction Patterns` and the following issues assigned to it:
 
-- `[Phase 9] Remove SyncUpdatingText and simplify the sync lifecycle`
-- `[Phase 9] Implement global navigation transition`
-- `[Phase 9] Build skeleton loader component`
-- `[Phase 9] Migrate all loading screens to skeleton loaders`
-- `[Phase 9] Fix AnimatedVisibility and animateContentSize gaps`
-- `[Phase 9] Define and implement standardised UX interaction patterns`
-
-## Open Questions
-
-- None. The motion, loading, and interaction rules for Phase 9 are now locked for implementation.
+- `[Phase 9] [9.1] Remove SyncUpdatingText and simplify the sync lifecycle`
+- `[Phase 9] [9.2] Implement global navigation transition`
+- `[Phase 9] [9.3] Build skeleton loader component`
+- `[Phase 9] [9.3] Migrate all loading screens to skeleton loaders`
+- `[Phase 9] [9.4] Fix AnimatedVisibility and animateContentSize gaps`
+- `[Phase 9] [9.5-9.6] Define and implement standardised UX interaction patterns`

--- a/app/src/main/java/com/example/lifetogether/domain/sync/SyncCoordinator.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/sync/SyncCoordinator.kt
@@ -14,14 +14,7 @@ import com.example.lifetogether.domain.usecase.sync.SyncRecipesUseCase
 import com.example.lifetogether.domain.usecase.sync.SyncTipTrackerUseCase
 import com.example.lifetogether.domain.usecase.sync.SyncUserInformationUseCase
 import com.example.lifetogether.domain.usecase.sync.SyncStartHandle
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -65,20 +58,6 @@ class SyncCoordinator @Inject constructor(
     private val activeSyncHandles: MutableMap<SyncKey, SyncStartHandle> = mutableMapOf()
     private val activeSyncContexts: MutableMap<SyncKey, SyncContext> = mutableMapOf()
     private val syncRefCounts: MutableMap<SyncKey, Int> = mutableMapOf()
-    private val firstSuccessMonitorJobs: MutableMap<SyncKey, Job> = mutableMapOf()
-
-    private val _syncStates =
-        MutableStateFlow(SyncKey.entries.associateWith { SyncState.IDLE })
-    val syncStates: StateFlow<Map<SyncKey, SyncState>> =
-        _syncStates.asStateFlow()
-
-    private val _activeSyncKeys = MutableStateFlow<Set<SyncKey>>(emptySet())
-    val activeSyncKeys: StateFlow<Set<SyncKey>> = _activeSyncKeys.asStateFlow()
-
-    private val _hasSyncedOnce =
-        MutableStateFlow(SyncKey.entries.associateWith { false })
-    val hasSyncedOnce: StateFlow<Map<SyncKey, Boolean>> =
-        _hasSyncedOnce.asStateFlow()
 
     fun syncGlobalSynchronizerContext(
         scope: CoroutineScope,
@@ -160,32 +139,10 @@ class SyncCoordinator @Inject constructor(
 
         stopSynchronizer(key)
 
-        val handle = createSynchronizerHandle(scope, key, context) ?: run {
-            _syncStates.update { it + (key to SyncState.IDLE) }
-            return
-        }
+        val handle = createSynchronizerHandle(scope, key, context) ?: return
 
         activeSyncContexts[key] = context
         activeSyncHandles[key] = handle
-        _activeSyncKeys.update { it + key }
-        _syncStates.update { it + (key to SyncState.UPDATING) }
-
-        firstSuccessMonitorJobs[key] = scope.launch {
-            try {
-                val firstSuccessResult = handle.firstSuccess.await()
-                val nextState = if (firstSuccessResult.isSuccess) {
-                    _hasSyncedOnce.update { it + (key to true) }
-                    SyncState.READY
-                } else {
-                    SyncState.FAILED
-                }
-                _syncStates.update { it + (key to nextState) }
-            } catch (_: CancellationException) {
-                // Synchronizer was stopped before first success.
-            } catch (_: Throwable) {
-                _syncStates.update { it + (key to SyncState.FAILED) }
-            }
-        }
     }
 
     private fun createSynchronizerHandle(
@@ -270,10 +227,7 @@ class SyncCoordinator @Inject constructor(
     }
 
     private fun stopSynchronizer(key: SyncKey) {
-        firstSuccessMonitorJobs.remove(key)?.cancel()
         activeSyncHandles.remove(key)?.job?.cancel()
         activeSyncContexts.remove(key)
-        _activeSyncKeys.update { it - key }
-        _syncStates.update { it + (key to SyncState.IDLE) }
     }
 }

--- a/app/src/main/java/com/example/lifetogether/domain/sync/SyncTypes.kt
+++ b/app/src/main/java/com/example/lifetogether/domain/sync/SyncTypes.kt
@@ -15,13 +15,6 @@ enum class SyncKey {
     ROUTINE_LIST_ENTRIES,
 }
 
-enum class SyncState {
-    IDLE,
-    UPDATING,
-    READY,
-    FAILED,
-}
-
 data class SyncContext(
     val uid: String? = null,
     val familyId: String? = null,

--- a/app/src/main/java/com/example/lifetogether/ui/common/sync/SyncLifecycle.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/common/sync/SyncLifecycle.kt
@@ -1,22 +1,12 @@
 package com.example.lifetogether.ui.common.sync
 
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.LocalActivity
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.lifetogether.domain.sync.SyncKey
-import com.example.lifetogether.domain.sync.SyncState
 import com.example.lifetogether.ui.common.di.rememberSyncCoordinator
 
 @Composable
@@ -31,8 +21,8 @@ fun FeatureSyncLifecycleBinding(
 
     DisposableEffect(lifecycleOwner, syncCoordinator, coroutineScope, keys) {
         fun acquireAll() = keys.forEach { key ->
-                syncCoordinator.acquireSynchronizer(scope = coroutineScope, key = key)
-            }
+            syncCoordinator.acquireSynchronizer(scope = coroutineScope, key = key)
+        }
 
         fun releaseAll() = keys.forEach(syncCoordinator::releaseSynchronizer)
 
@@ -53,32 +43,5 @@ fun FeatureSyncLifecycleBinding(
             lifecycleOwner.lifecycle.removeObserver(observer)
             releaseAll()
         }
-    }
-}
-
-@Composable
-fun SyncUpdatingText(
-    keys: Set<SyncKey>,
-) {
-    val syncCoordinator = rememberSyncCoordinator()
-
-    val syncStates by syncCoordinator.syncStates.collectAsStateWithLifecycle()
-    val activeKeys by syncCoordinator.activeSyncKeys.collectAsStateWithLifecycle()
-    val hasSyncedOnce by syncCoordinator.hasSyncedOnce.collectAsStateWithLifecycle()
-
-    val activeKeysAwaitingFirstSuccess = keys.filter { key ->
-        key in activeKeys &&
-            syncStates[key] == SyncState.UPDATING &&
-            hasSyncedOnce[key] != true
-    }
-
-    if (activeKeysAwaitingFirstSuccess.isNotEmpty()) {
-        Text(
-            text = "Updating...",
-            modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.secondary,
-            textAlign = TextAlign.Center,
-        )
     }
 }

--- a/app/src/main/java/com/example/lifetogether/ui/feature/admin/groceryList/categories/AdminGroceryCategoriesScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/admin/groceryList/categories/AdminGroceryCategoriesScreen.kt
@@ -29,10 +29,8 @@ import androidx.compose.ui.unit.dp
 import com.example.lifetogether.R
 import com.example.lifetogether.domain.model.Category
 import com.example.lifetogether.domain.model.Icon
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialog
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.text.TextHeadingMedium
 import com.example.lifetogether.ui.common.textfield.CustomTextField
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
@@ -69,10 +67,6 @@ fun AdminGroceryCategoriesScreen(
         ) {
 
             item {
-                SyncUpdatingText(keys = setOf(SyncKey.GROCERY_CATEGORIES))
-
-                Spacer(modifier = Modifier.height(LifeTogetherTokens.spacing.small))
-
                 Text(
                     modifier = Modifier.padding(horizontal = LifeTogetherTokens.spacing.xSmall),
                     text = "Add new category as a string with an emoji and a name with whitespace between e.g. \"\uD83C\uDF5E Bakery\"",

--- a/app/src/main/java/com/example/lifetogether/ui/feature/admin/groceryList/suggestions/AdminGrocerySuggestionsScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/admin/groceryList/suggestions/AdminGrocerySuggestionsScreen.kt
@@ -19,12 +19,10 @@ import com.example.lifetogether.R
 import com.example.lifetogether.domain.model.Category
 import com.example.lifetogether.domain.model.Icon
 import com.example.lifetogether.domain.model.grocery.GrocerySuggestion
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.add.AddNewListItem
 import com.example.lifetogether.ui.common.add.EditListItem
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialog
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.text.TextHeadingMedium
 import com.example.lifetogether.ui.theme.LifeTogetherTokens
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
@@ -57,12 +55,6 @@ fun AdminGrocerySuggestionsScreen(
                     .padding(bottom = LifeTogetherTokens.spacing.bottomInsetMedium),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            SyncUpdatingText(
-                keys = setOf(SyncKey.GROCERY_CATEGORIES, SyncKey.GROCERY_SUGGESTIONS),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
             Text(
                 modifier = Modifier.padding(horizontal = LifeTogetherTokens.spacing.xSmall),
                 text = "Add a new suggestion by choosing the category (emoji) and writing the suggestion name.",

--- a/app/src/main/java/com/example/lifetogether/ui/feature/gallery/AlbumDetailsScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/gallery/AlbumDetailsScreen.kt
@@ -44,9 +44,7 @@ import com.example.lifetogether.ui.common.image.MediaUploadMultipleDialog
 import com.example.lifetogether.ui.common.list.CompletableBox
 import com.example.lifetogether.ui.common.text.TextDefault
 import com.example.lifetogether.ui.common.text.TextSubHeadingMedium
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.model.MenuAction
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
 import com.example.lifetogether.ui.theme.LifeTogetherTokens
 
@@ -102,9 +100,6 @@ fun AlbumDetailsScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small),
             ) {
-                SyncUpdatingText(
-                    keys = setOf(SyncKey.GALLERY_ALBUMS, SyncKey.GALLERY_MEDIA),
-                )
                 when (uiState.isSelectionModeActive) {
                     true -> {
                         Row(

--- a/app/src/main/java/com/example/lifetogether/ui/feature/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/gallery/GalleryScreen.kt
@@ -1,7 +1,6 @@
 package com.example.lifetogether.ui.feature.gallery
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,8 +19,6 @@ import com.example.lifetogether.domain.model.Icon
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.button.AddButton
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialogWithTextField
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.model.AlbumUiModel
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
 import com.example.lifetogether.ui.theme.LifeTogetherTokens
@@ -60,27 +57,23 @@ fun GalleryScreen(
             verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.xLarge),
         ) {
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small)) {
-                    SyncUpdatingText(keys = setOf(SyncKey.GALLERY_ALBUMS, SyncKey.GALLERY_MEDIA))
-
-                    if (uiState.albums.isEmpty()) {
-                        Text(text = "No albums created. Press + to create one.")
-                    } else {
-                        FlowRow(
-                            modifier = Modifier.fillMaxWidth(),
-                            maxItemsInEachRow = 2,
-                            verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small),
-                        ) {
-                            for (album in uiState.albums) {
-                                AlbumCard(
-                                    album.name,
-                                    album.mediaCount,
-                                    album.thumbnail?.toBitmap(),
-                                    onClick = {
-                                        onNavigationEvent(GalleryNavigationEvent.NavigateToAlbumMedia(album.id))
-                                    },
-                                )
-                            }
+                if (uiState.albums.isEmpty()) {
+                    Text(text = "No albums created. Press + to create one.")
+                } else {
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        maxItemsInEachRow = 2,
+                        verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small),
+                    ) {
+                        for (album in uiState.albums) {
+                            AlbumCard(
+                                album.name,
+                                album.mediaCount,
+                                album.thumbnail?.toBitmap(),
+                                onClick = {
+                                    onNavigationEvent(GalleryNavigationEvent.NavigateToAlbumMedia(album.id))
+                                },
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/example/lifetogether/ui/feature/gallery/MediaDetailsScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/gallery/MediaDetailsScreen.kt
@@ -41,10 +41,8 @@ import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialog
 import com.example.lifetogether.ui.common.image.DisplayImageFromUri
 import com.example.lifetogether.ui.common.image.DisplayVideoFromUri
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.text.TextDefault
 import com.example.lifetogether.ui.model.MenuAction
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
 import com.example.lifetogether.ui.theme.LifeTogetherTokens
 import java.util.Date
@@ -112,10 +110,6 @@ fun MediaDetailsScreen(
                     .padding(LifeTogetherTokens.spacing.small),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                SyncUpdatingText(
-                    keys = setOf(SyncKey.GALLERY_ALBUMS, SyncKey.GALLERY_MEDIA),
-                )
-
                 HorizontalPager(
                     state = pagerState,
                     modifier = Modifier

--- a/app/src/main/java/com/example/lifetogether/ui/feature/groceryList/GroceryListScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/groceryList/GroceryListScreen.kt
@@ -17,12 +17,10 @@ import com.example.lifetogether.R
 import com.example.lifetogether.domain.model.Category
 import com.example.lifetogether.domain.model.Icon
 import com.example.lifetogether.domain.model.grocery.GroceryItem
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.add.AddNewListItem
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialog
 import com.example.lifetogether.ui.common.list.ItemCategoryList
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.text.TextDefault
 import com.example.lifetogether.ui.common.text.TextSubHeadingMedium
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
@@ -61,14 +59,6 @@ fun GroceryListScreen(
         ) {
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small)) {
-                    SyncUpdatingText(
-                        keys = setOf(
-                            SyncKey.GROCERY_LIST,
-                            SyncKey.GROCERY_CATEGORIES,
-                            SyncKey.GROCERY_SUGGESTIONS,
-                        ),
-                    )
-
                     if (uiState.groceryList.isEmpty()) {
                         TextDefault(text = "No items on the list yet")
                     } else {

--- a/app/src/main/java/com/example/lifetogether/ui/feature/guides/GuidesScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/guides/GuidesScreen.kt
@@ -43,8 +43,6 @@ import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.button.PrimaryButton
 import com.example.lifetogether.ui.common.button.SecondaryButton
 import com.example.lifetogether.ui.common.button.AddButton
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.common.text.TextHeadingMedium
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
 import com.example.lifetogether.ui.theme.LifeTogetherTokens
@@ -118,10 +116,6 @@ fun GuidesScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.medium),
         ) {
-            item {
-                SyncUpdatingText(keys = setOf(SyncKey.GUIDES))
-            }
-
             if (uiState.guides.isEmpty()) {
                 item {
                     Text(text = "No guides yet. Tap + to create or import one.")

--- a/app/src/main/java/com/example/lifetogether/ui/feature/lists/ListsScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/lists/ListsScreen.kt
@@ -27,12 +27,10 @@ import com.example.lifetogether.domain.model.Icon
 import com.example.lifetogether.domain.model.enums.Visibility
 import com.example.lifetogether.domain.model.lists.ListType
 import com.example.lifetogether.domain.model.lists.UserList
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.button.PrimaryButton
 import com.example.lifetogether.ui.common.button.SecondaryButton
 import com.example.lifetogether.ui.common.button.AddButton
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.text.TextDefault
 import com.example.lifetogether.ui.common.text.TextHeadingMedium
 import com.example.lifetogether.ui.common.textfield.CustomTextField
@@ -69,10 +67,6 @@ fun ListsScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.medium),
         ) {
-            item {
-                SyncUpdatingText(keys = setOf(SyncKey.USER_LISTS, SyncKey.ROUTINE_LIST_ENTRIES))
-            }
-
             if (uiState.userLists.isEmpty()) {
                 item {
                     TextDefault(text = "No lists yet. Tap + to create one.")

--- a/app/src/main/java/com/example/lifetogether/ui/feature/lists/listDetails/ListDetailsScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/lists/listDetails/ListDetailsScreen.kt
@@ -34,14 +34,12 @@ import com.example.lifetogether.R
 import com.example.lifetogether.domain.model.Icon
 import com.example.lifetogether.domain.model.lists.RecurrenceUnit
 import com.example.lifetogether.domain.model.lists.RoutineListEntry
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.common.ActionSheet
 import com.example.lifetogether.ui.common.ActionSheetItem
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.button.AddButton
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialog
 import com.example.lifetogether.ui.common.list.CompletableBox
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.text.TextDefault
 import com.example.lifetogether.ui.common.text.TextHeadingMedium
 import com.example.lifetogether.ui.theme.LifeTogetherTheme
@@ -106,8 +104,6 @@ fun ListDetailsScreen(
                         .padding(horizontal = LifeTogetherTokens.spacing.small),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    SyncUpdatingText(keys = setOf(SyncKey.ROUTINE_LIST_ENTRIES))
-
                     if (uiState.isSelectionModeActive) {
                         SelectionModeBar(
                             selectedCount = uiState.selectedEntryIds.size,

--- a/app/src/main/java/com/example/lifetogether/ui/feature/recipes/RecipesScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/recipes/RecipesScreen.kt
@@ -11,15 +11,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.lifetogether.R
-import com.example.lifetogether.ui.common.button.AddButton
-import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.domain.model.Icon
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
-import com.example.lifetogether.ui.common.tagOptionRow.TagOptionRow
-import com.example.lifetogether.ui.theme.LifeTogetherTheme
 import com.example.lifetogether.domain.model.recipe.Recipe
-import com.example.lifetogether.domain.sync.SyncKey
+import com.example.lifetogether.ui.common.TopBar
+import com.example.lifetogether.ui.common.button.AddButton
+import com.example.lifetogether.ui.common.tagOptionRow.TagOptionRow
 import com.example.lifetogether.ui.theme.LifeTogetherTokens
+import com.example.lifetogether.ui.theme.LifeTogetherTheme
 
 @Composable
 fun RecipesScreen(
@@ -56,17 +54,13 @@ fun RecipesScreen(
             verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.xLarge),
         ) {
             item {
-                Column(verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small)) {
-                    SyncUpdatingText(keys = setOf(SyncKey.RECIPES))
-
-                    TagOptionRow(
-                        options = uiState.tagsList,
-                        selectedOption = uiState.selectedTag,
-                        onSelectedOptionChange = {
-                            onUiEvent(RecipesUiEvent.TagSelected(it))
-                        },
-                    )
-                }
+                TagOptionRow(
+                    options = uiState.tagsList,
+                    selectedOption = uiState.selectedTag,
+                    onSelectedOptionChange = {
+                        onUiEvent(RecipesUiEvent.TagSelected(it))
+                    },
+                )
             }
 
             item {

--- a/app/src/main/java/com/example/lifetogether/ui/feature/tipTracker/TipTrackerScreen.kt
+++ b/app/src/main/java/com/example/lifetogether/ui/feature/tipTracker/TipTrackerScreen.kt
@@ -16,9 +16,7 @@ import com.example.lifetogether.domain.model.TipItem
 import com.example.lifetogether.domain.model.Icon
 import com.example.lifetogether.ui.common.TopBar
 import com.example.lifetogether.ui.common.dialog.ConfirmationDialog
-import com.example.lifetogether.ui.common.sync.SyncUpdatingText
 import com.example.lifetogether.ui.common.tagOptionRow.TagOptionRow
-import com.example.lifetogether.domain.sync.SyncKey
 import com.example.lifetogether.ui.feature.tipTracker.components.AddNewTipItem
 import com.example.lifetogether.ui.feature.tipTracker.components.TipsCalendar
 import com.example.lifetogether.ui.feature.tipTracker.components.TipsList
@@ -65,8 +63,6 @@ fun TipTrackerScreen(
         ) {
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(LifeTogetherTokens.spacing.small)) {
-                    SyncUpdatingText(keys = setOf(SyncKey.TIP_TRACKER))
-
                     if (content.tips.isNotEmpty()) {
                         TagOptionRow(
                             options = listOf("Calendar", "List"),


### PR DESCRIPTION
…m app/src/main/java/com/example/lifetogether/domain/sync/SyncCoordinator.kt.

  - Deleted SyncUpdatingText and kept only FeatureSyncLifecycleBinding in app/src/main/java/com/example/lifetogether/ui/common/sync/SyncLifecycle.kt.
  - Removed the SyncState enum from app/src/main/java/com/example/lifetogether/domain/sync/SyncTypes.kt.
  - Stripped the sync text call sites and collapsed the related layout slots across the affected screens, including app/src/main/java/com/example/lifetogether/ui/feature/gallery/ GalleryScreen.kt, app/src/main/java/com/example/lifetogether/ui/feature/recipes/RecipesScreen.kt, app/src/main/java/com/example/lifetogether/ui/feature/lists/ListsScreen.kt, and the other sync-text screens in the same pass.